### PR TITLE
Removed items from the menu are not being rendered anymore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -798,6 +800,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,8 +510,6 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
@@ -800,7 +798,6 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 

--- a/lib/decidim/decidim_awesome/menu_hacker.rb
+++ b/lib/decidim/decidim_awesome/menu_hacker.rb
@@ -36,7 +36,7 @@ module Decidim
       attr_reader :name, :view
 
       def default_items
-        @default_items ||= build_menu.instance_variable_get(:@items).map do |item|
+        @default_items ||= build_menu.items.map do |item|
           item.instance_variable_set(:@active, method(:activate?)) unless item.active == :exact
           item
         end

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -94,7 +94,7 @@ module Decidim
     end
 
     shared_examples "removed item is not present" do
-      include_context "removes item"
+      include_context "when an item is removed"
 
       it "renders the menu as a navigation list" do
         expect(subject.render).to \
@@ -116,7 +116,7 @@ module Decidim
     end
 
     shared_examples "removed item is not present and other items are overridden" do
-      include_context "removes item"
+      include_context "when an item is removed"
 
       it "renders the menu as a navigation list" do
         expect(subject.render).to \

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -42,7 +42,7 @@ module Decidim
       Decidim::DecidimAwesome.config.except!(:custom_menu)
     end
 
-    shared_examples "removes item" do
+    shared_context "removes item" do
       before do
         Decidim.menu :custom_menu do |menu|
           menu.remove_item :native_bar

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -71,7 +71,7 @@ module Decidim
       end
     end
 
-    shared_examples "has overriden items" do
+    shared_examples "has overridden items" do
       it "renders the menu as a navigation list" do
         expect(subject.render).to \
           have_selector("ul") &
@@ -138,12 +138,12 @@ module Decidim
       end
     end
 
-    context "when overrided menu is not an awesome config var" do
+    context "when overrode menu is not an awesome config var" do
       it_behaves_like "has default items"
       it_behaves_like "removed item is not present"
     end
 
-    context "when overrided menu is disabled" do
+    context "when overrode menu is disabled" do
       before do
         Decidim::DecidimAwesome.config[:custom_menu] = :disabled
       end
@@ -152,12 +152,12 @@ module Decidim
       it_behaves_like "removed item is not present"
     end
 
-    context "when overrided menu is enabled" do
+    context "when overrode menu is enabled" do
       before do
         Decidim::DecidimAwesome.config[:custom_menu] = []
       end
 
-      it_behaves_like "has overriden items"
+      it_behaves_like "has overridden items"
       it_behaves_like "removed item is not present and other items are overridden"
     end
   end

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -42,7 +42,7 @@ module Decidim
       Decidim::DecidimAwesome.config.except!(:custom_menu)
     end
 
-    shared_context "removes item" do
+    shared_context "when an item is removed" do
       before do
         Decidim.menu :custom_menu do |menu|
           menu.remove_item :native_bar

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -42,6 +42,14 @@ module Decidim
       Decidim::DecidimAwesome.config.except!(:custom_menu)
     end
 
+    shared_examples "removes item" do
+      before do
+        Decidim.menu :custom_menu do |menu|
+          menu.remove_item :native_bar
+        end
+      end
+    end
+
     shared_examples "has default items" do
       it "renders the menu as a navigation list and skips non visible" do
         expect(subject.render).to \
@@ -85,8 +93,54 @@ module Decidim
       end
     end
 
+    shared_examples "removed item is not present" do
+      include_context "removes item"
+
+      it "renders the menu as a navigation list" do
+        expect(subject.render).to \
+          have_selector("ul") &
+          have_selector("li", count: 1) &
+          have_link("Foo", href: "/foo")
+      end
+
+      it "renders the menu in the right order" do
+        expect(subject.render).to \
+          have_selector("ul") &
+          have_selector("li:first-child", text: "Foo") &
+          have_selector("li:last-child", text: "Foo")
+      end
+
+      it "returns instance of Decidim:Menu" do
+        expect(subject.evaluated_menu).to be_a(Decidim::Menu)
+      end
+    end
+
+    shared_examples "removed item is not present and other items are overridden" do
+      include_context "removes item"
+
+      it "renders the menu as a navigation list" do
+        expect(subject.render).to \
+          have_selector("ul") &
+          have_selector("li", count: 2) &
+          have_link("Baz", href: "/baz") &
+          have_link("Fumanchu", href: "/foo")
+      end
+
+      it "renders the menu in the right order" do
+        expect(subject.render).to \
+          have_selector("ul") &
+          have_selector("li:first-child", text: "Baz") &
+          have_selector("li:last-child", text: "Fumanchu")
+      end
+
+      it "returns instance of Decidim:Menu" do
+        expect(subject.evaluated_menu).to be_a(Decidim::DecidimAwesome::MenuHacker)
+      end
+    end
+
     context "when overrided menu is not an awesome config var" do
       it_behaves_like "has default items"
+      it_behaves_like "removed item is not present"
     end
 
     context "when overrided menu is disabled" do
@@ -95,6 +149,7 @@ module Decidim
       end
 
       it_behaves_like "has default items"
+      it_behaves_like "removed item is not present"
     end
 
     context "when overrided menu is enabled" do
@@ -103,6 +158,7 @@ module Decidim
       end
 
       it_behaves_like "has overriden items"
+      it_behaves_like "removed item is not present and other items are overridden"
     end
   end
 end

--- a/spec/system/admin/admin_manages_menu_overrides_spec.rb
+++ b/spec/system/admin/admin_manages_menu_overrides_spec.rb
@@ -34,7 +34,6 @@ describe "Admin manages hacked menus", type: :system do
     it "shows default menu items" do
       within "table tbody" do
         expect(page).to have_content("Home")
-        expect(page).to have_content("Assemblies")
         expect(page).to have_content("Processes")
         expect(page).to have_content("Help")
       end
@@ -67,7 +66,6 @@ describe "Admin manages hacked menus", type: :system do
         expect(page).to have_content("Home")
         expect(page).to have_content("Blog")
         expect(page).to have_content("http://external.blog")
-        expect(page).to have_content("Assemblies")
         expect(page).to have_content("Processes")
         expect(page).to have_content("Help")
       end


### PR DESCRIPTION
Fixes #213 

Use `items` instead of `@items` on `Decidim::Menu` instance as this method excludes removed and not visible items: 

```ruby
def items
  @items.reject! { |item| @removed_items.include?(item.identifier) }
  @ordered_elements.each { |item| move_element(item) }
  @items.select(&:visible?).sort_by(&:position)
end
```