### PR TITLE
Treat proposals with no state as notAnswered

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -819,7 +819,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.0.2p107
+   ruby 3.0.5p211
 
 BUNDLED WITH
-   2.4.15
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -819,7 +819,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.0.5p211
+   ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.33
+   2.4.15

--- a/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
+++ b/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
@@ -29,7 +29,7 @@ export default class Controller {
       return withdrawn && node.state === "withdrawn" ||
         accepted && node.state === "accepted" ||
         evaluating && node.state === "evaluating" ||
-        notAnswered && node.state === "notAnswered" ||
+        notAnswered && (node.state === "notAnswered" || node.state === null) ||
         rejected && node.state === "rejected";
     }
 

--- a/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
+++ b/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
@@ -24,13 +24,7 @@ export default class Controller {
   setFetcher(Fetcher) {
     let checkProposalState = function (node, map) {
       const showConfig = map.config.show;
-      const { withdrawn, accepted, evaluating, notAnswered, rejected } = showConfig;
-
-      return withdrawn && node.state === "withdrawn" ||
-        accepted && node.state === "accepted" ||
-        evaluating && node.state === "evaluating" ||
-        notAnswered && (node.state === "notAnswered" || node.state === null) ||
-        rejected && node.state === "rejected";
+      return showConfig[node.state] || showConfig.notAnswered;
     }
 
     this.fetcher = new Fetcher(this);

--- a/spec/system/awesome_map_spec.rb
+++ b/spec/system/awesome_map_spec.rb
@@ -13,7 +13,7 @@ describe "Show awesome map", type: :system do
   let!(:accepted_proposal) { create(:proposal, :accepted, component: proposal_component, latitude: 40, longitude: -50) }
   let!(:evaluating_proposal) { create(:proposal, :evaluating, component: proposal_component, latitude: 30, longitude: 45) }
   let!(:not_answered_proposal) { create(:proposal, :not_answered, component: proposal_component, latitude: 70, longitude: 6) }
-  let!(:null_state_proposal) { create(:proposal, nil, component: proposal_component, latitude: 50, longitude: 10) }
+  let!(:null_state_proposal) { create(:proposal, state: nil, component: proposal_component, latitude: 50, longitude: 10) }
   let!(:withdrawn_proposal) { create(:proposal, :withdrawn, component: proposal_component, latitude: 60, longitude: -30) }
   let!(:rejected_proposal) { create(:proposal, :rejected, component: proposal_component, latitude: 10, longitude: 80) }
   let!(:category) { create(:category, participatory_space: participatory_process) }
@@ -32,13 +32,15 @@ describe "Show awesome map", type: :system do
       show_accepted: show_accepted,
       show_evaluating: show_evaluating,
       show_rejected: show_rejected,
-      show_withdrawn: show_withdrawn
+      show_withdrawn: show_withdrawn,
+      show_not_answered: show_not_answered
     }
   end
   let(:show_accepted) { true }
   let(:show_evaluating) { true }
   let(:show_rejected) { true }
   let(:show_withdrawn) { true }
+  let(:show_not_answered) { true }
 
   let(:show_amendments) { true }
   let(:show_meetings) { true }
@@ -97,6 +99,7 @@ describe "Show awesome map", type: :system do
       expect(page.body).to have_selector("div[title='#{evaluating_proposal.title["en"]}']")
       expect(page.body).to have_selector("div[title='#{rejected_proposal.title["en"]}']")
       expect(page.body).to have_selector("div[title='#{withdrawn_proposal.title["en"]}']")
+      expect(page.body).to have_selector("div[title='#{null_state_proposal.title["en"]}']")
     end
   end
 
@@ -105,6 +108,7 @@ describe "Show awesome map", type: :system do
     let(:show_evaluating) { false }
     let(:show_rejected) { false }
     let(:show_withdrawn) { false }
+    let(:show_not_answered) { false }
 
     it "does not show any proposal" do
       sleep(1)
@@ -112,6 +116,7 @@ describe "Show awesome map", type: :system do
       expect(page.body).not_to have_selector("div[title='#{evaluating_proposal.title["en"]}']")
       expect(page.body).not_to have_selector("div[title='#{rejected_proposal.title["en"]}']")
       expect(page.body).not_to have_selector("div[title='#{withdrawn_proposal.title["en"]}']")
+      expect(page.body).not_to have_selector("div[title='#{null_state_proposal.title["en"]}']")
     end
   end
 

--- a/spec/system/awesome_map_spec.rb
+++ b/spec/system/awesome_map_spec.rb
@@ -13,6 +13,7 @@ describe "Show awesome map", type: :system do
   let!(:accepted_proposal) { create(:proposal, :accepted, component: proposal_component, latitude: 40, longitude: -50) }
   let!(:evaluating_proposal) { create(:proposal, :evaluating, component: proposal_component, latitude: 30, longitude: 45) }
   let!(:not_answered_proposal) { create(:proposal, :not_answered, component: proposal_component, latitude: 70, longitude: 6) }
+  let!(:null_state_proposal) { create(:proposal, nil, component: proposal_component, latitude: 50, longitude: 10) }
   let!(:withdrawn_proposal) { create(:proposal, :withdrawn, component: proposal_component, latitude: 60, longitude: -30) }
   let!(:rejected_proposal) { create(:proposal, :rejected, component: proposal_component, latitude: 10, longitude: 80) }
   let!(:category) { create(:category, participatory_space: participatory_process) }


### PR DESCRIPTION
Proposals in a null state were not being displayed on the Map.
![before](https://github.com/decidim-ice/decidim-module-decidim_awesome/assets/72018461/ad71c919-3033-4b21-b736-353a9ac4cbc1)
The problem has been resolved by treating the null state proposals as "notAnswered" ones, making them visible on the Map when the "Show not answered proposals" option is enabled in the configuration.
![after](https://github.com/decidim-ice/decidim-module-decidim_awesome/assets/72018461/e9f658a6-1762-46d0-a31f-6de3bd782c0c)
