### PR TITLE
Fix wrong behavior showing proposals on map

### DIFF
--- a/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
+++ b/app/packs/src/decidim/decidim_awesome/awesome_map/controllers/controller.js
@@ -24,7 +24,7 @@ export default class Controller {
   setFetcher(Fetcher) {
     let checkProposalState = function (node, map) {
       const showConfig = map.config.show;
-      return showConfig[node.state] || showConfig.notAnswered;
+      return showConfig[node.state || "notAnswered"];
     }
 
     this.fetcher = new Fetcher(this);

--- a/spec/system/awesome_map_spec.rb
+++ b/spec/system/awesome_map_spec.rb
@@ -120,6 +120,23 @@ describe "Show awesome map", type: :system do
     end
   end
 
+  context "when only the not answered option is enabled" do
+    let(:show_accepted) { false }
+    let(:show_evaluating) { false }
+    let(:show_rejected) { false }
+    let(:show_withdrawn) { false }
+    let(:show_not_answered) { true }
+
+    it "only shows proposal without state" do
+      sleep(1)
+      expect(page.body).not_to have_selector("div[title='#{accepted_proposal.title["en"]}']")
+      expect(page.body).not_to have_selector("div[title='#{evaluating_proposal.title["en"]}']")
+      expect(page.body).not_to have_selector("div[title='#{rejected_proposal.title["en"]}']")
+      expect(page.body).not_to have_selector("div[title='#{withdrawn_proposal.title["en"]}']")
+      expect(page.body).to have_selector("div[title='#{null_state_proposal.title["en"]}']")
+    end
+  end
+
   # TODO: figure out a way to test leaflet without any map provider
   # it "shows the proposal component as a menu" do
   #   expect(page.body).to have_content(".awesome_map-component_#{component.id}")


### PR DESCRIPTION
Fixes #235.

This issue appeared after merging #225 as there was a bug in the solution that made the visibility of the proposal the same as the configured for "not answered" when the state of the proposal is set as false.