### PR TITLE
Fix to hide components from different organizations

### DIFF
--- a/app/cells/decidim/decidim_awesome/content_blocks/map_cell.rb
+++ b/app/cells/decidim/decidim_awesome/content_blocks/map_cell.rb
@@ -40,11 +40,15 @@ module Decidim
 
         def global_map_components
           @global_map_components ||= Decidim::Component.where(manifest_name: [:meetings, :proposals]).published.filter do |component|
-            case component.manifest.name
-            when :meetings
-              true
-            when :proposals
-              component.settings.geocoding_enabled
+            if component.organization == current_organization
+              case component.manifest.name
+              when :meetings
+                true
+              when :proposals
+                component.settings.geocoding_enabled
+              else
+                false
+              end
             else
               false
             end

--- a/spec/cells/content_blocks/map_cell_spec.rb
+++ b/spec/cells/content_blocks/map_cell_spec.rb
@@ -116,5 +116,26 @@ module Decidim::DecidimAwesome
         expect(subject.to_s).to include('data-show-rejected="true"')
       end
     end
+
+    context "with another organization" do
+      subject { cell(another_content_block.cell, another_content_block).call }
+
+      let(:another_organization) { create(:organization) }
+      let(:another_content_block) { create :content_block, organization: another_organization, manifest_name: :awesome_map, scope_name: :homepage, settings: settings }
+      let(:another_participatory_process) { create :participatory_process, organization: another_organization }
+      let!(:another_meeting_component) { create :meeting_component, participatory_space: another_participatory_process }
+
+      before do
+        allow(controller).to receive(:current_organization).and_return(another_organization)
+      end
+
+      it "uses its own components" do
+        components = JSON.parse(subject.to_s.match(/data-components='(.*)'/)[1])
+
+        expect(components.pluck("id")).not_to include(meeting_component.id)
+        expect(components.pluck("id")).not_to include(proposal_component.id)
+        expect(components.pluck("id")).to include(another_meeting_component.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
In a Decidim instance with multiple organizations using DecidimAwesome, there are cases where information about components not belonging to the current organization is displayed in AwesomeMap. This PR fixes that issue.