### PR TITLE
reorder settings for components

### DIFF
--- a/lib/decidim/decidim_awesome.rb
+++ b/lib/decidim/decidim_awesome.rb
@@ -14,7 +14,6 @@ require "decidim/decidim_awesome/iframe_component/component"
 require "decidim/decidim_awesome/content_parsers/editor_images_parser"
 
 # Engines to handle logic unrelated to participatory spaces or components
-
 Decidim.register_global_engine(
   :decidim_decidim_awesome, # this is the name of the global method to access engine routes
   Decidim::DecidimAwesome::Engine,

--- a/lib/decidim/decidim_awesome/awesome.rb
+++ b/lib/decidim/decidim_awesome/awesome.rb
@@ -293,6 +293,24 @@ module Decidim
       end
     end
 
+    # appends to a hash a new value in a specified position so that the hash becomes:
+    # { a: 1, b: 2, c: 3 } => append_hash(hash, :b, :d, 4) => { a: 1, b: 2, d: 4, c: 3 }
+    # if key is not found then it will be inserted at the end
+    def self.hash_append!(hash, after_key, key, value)
+      insert_at = hash.to_a.index(hash.assoc(after_key))
+      insert_at = insert_at.nil? ? hash.size : insert_at + 1
+      hash.replace(hash.to_a.insert(insert_at, [key, value]).to_h)
+    end
+
+    # prepends to a hash a new value in a specified position so that the hash becomes:
+    # { a: 1, b: 2, c: 3 } => prepend_hash(hash, :b, :d, 4) => { a: 1, d: 4, b: 2, c: 3 }
+    # if key is not found then it will be inserted at the beggining
+    def self.hash_prepend!(hash, before_key, key, value)
+      insert_at = hash.to_a.index(hash.assoc(before_key))
+      insert_at = 0 if insert_at.nil?
+      hash.replace(hash.to_a.insert(insert_at, [key, value]).to_h)
+    end
+
     def self.collation_for(locale)
       @collation_for ||= {}
       @collation_for[locale] ||= begin

--- a/lib/decidim/decidim_awesome/engine.rb
+++ b/lib/decidim/decidim_awesome/engine.rb
@@ -111,10 +111,10 @@ module Decidim
         app.config.middleware.insert_after Decidim::Middleware::CurrentOrganization, Decidim::DecidimAwesome::CurrentConfig
       end
 
-      initializer "decidim_decidim_awesome.additional_proposal_sortings" do |_app|
-        if DecidimAwesome.enabled?(:additional_proposal_sortings)
-          Decidim.component_registry.find(:proposals).tap do |component|
-            component.settings(:global) do |settings|
+      initializer "decidim_decidim_awesome.additional_proposal_options" do |_app|
+        Decidim.component_registry.find(:proposals).tap do |component|
+          component.settings(:global) do |settings|
+            if DecidimAwesome.enabled?(:additional_proposal_sortings)
               settings.attribute(
                 :default_sort_order,
                 type: :select,
@@ -122,6 +122,16 @@ module Decidim
                 choices: -> { (POSSIBLE_SORT_ORDERS + DecidimAwesome.possible_additional_proposal_sortings).uniq }
               )
             end
+            if DecidimAwesome.enabled?(:allow_limiting_amendments)
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :amendments_enabled,
+                :limit_pending_amendments,
+                Decidim::SettingsManifest::Attribute.new(type: :boolean, default: DecidimAwesome.allow_limiting_amendments)
+              )
+            end
+          end
+          if DecidimAwesome.enabled?(:additional_proposal_sortings)
             component.settings(:step) do |settings|
               settings.attribute(
                 :default_sort_order,
@@ -129,13 +139,6 @@ module Decidim
                 include_blank: true,
                 choices: -> { (POSSIBLE_SORT_ORDERS + DecidimAwesome.possible_additional_proposal_sortings).uniq }
               )
-            end
-          end
-        end
-        if DecidimAwesome.enabled?(:allow_limiting_amendments)
-          Decidim.component_registry.find(:proposals).tap do |component|
-            component.settings(:global) do |settings|
-              settings.attribute :limit_pending_amendments, type: :boolean, default: DecidimAwesome.allow_limiting_amendments
             end
           end
         end
@@ -161,26 +164,43 @@ module Decidim
             next unless component
 
             component.settings(:global) do |settings|
-              settings.attribute :awesome_voting_manifest,
-                                 type: :select,
-                                 default: "",
-                                 choices: -> { ["default"] + Decidim::DecidimAwesome.voting_registry.manifests.map(&:name) },
-                                 readonly: lambda { |context|
-                                   Decidim::Proposals::Proposal.where(component: context[:component]).where.not(proposal_votes_count: -Float::INFINITY..0).any?
-                                 }
-              settings.attribute :voting_cards_box_title,
-                                 type: :string,
-                                 translated: true
-              settings.attribute :voting_cards_show_modal_help,
-                                 type: :boolean,
-                                 default: true
-              settings.attribute :voting_cards_show_abstain,
-                                 type: :boolean,
-                                 default: false
-              settings.attribute :voting_cards_instructions,
-                                 type: :text,
-                                 translated: true,
-                                 editor: true
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :can_accumulate_supports_beyond_threshold,
+                :awesome_voting_manifest,
+                Decidim::SettingsManifest::Attribute.new(
+                  type: :select,
+                  default: "",
+                  choices: -> { ["default"] + Decidim::DecidimAwesome.voting_registry.manifests.map(&:name) },
+                  readonly: lambda { |context|
+                    Decidim::Proposals::Proposal.where(component: context[:component]).where.not(proposal_votes_count: -Float::INFINITY..0).any?
+                  }
+                )
+              )
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :awesome_voting_manifest,
+                :voting_cards_box_title,
+                Decidim::SettingsManifest::Attribute.new(type: :string, translated: true)
+              )
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :voting_cards_box_title,
+                :voting_cards_show_modal_help,
+                Decidim::SettingsManifest::Attribute.new(type: :boolean, default: true)
+              )
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :voting_cards_show_modal_help,
+                :voting_cards_show_abstain,
+                Decidim::SettingsManifest::Attribute.new(type: :boolean, default: false)
+              )
+              DecidimAwesome.hash_append!(
+                settings.attributes,
+                :voting_cards_show_abstain,
+                :voting_cards_instructions,
+                Decidim::SettingsManifest::Attribute.new(type: :text, translated: true, editor: true)
+              )
             end
           end
         end

--- a/spec/lib/awesome_spec.rb
+++ b/spec/lib/awesome_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe DecidimAwesome do
+    subject { described_class }
+
+    it "has a voting registry" do
+      expect(subject.voting_registry).to be_a(Decidim::ManifestRegistry)
+    end
+
+    it "returns the database collation" do
+      expect(subject.collation_for("en")).to start_with("en")
+    end
+
+    describe "#hash_append!" do
+      let(:hash) do
+        { a: 1, b: 2, c: 3 }
+      end
+
+      it "append a value at the second position" do
+        subject.hash_append!(hash, :a, :d, 4)
+        expect(hash).to eq({ a: 1, d: 4, b: 2, c: 3 })
+      end
+
+      it "append a value at the last position" do
+        subject.hash_append!(hash, :c, :d, 4)
+        expect(hash).to eq({ a: 1, b: 2, c: 3, d: 4 })
+      end
+
+      context "when key is not found" do
+        it "append a value at the last position" do
+          subject.hash_append!(hash, :z, :d, 4)
+          expect(hash).to eq({ a: 1, b: 2, c: 3, d: 4 })
+        end
+      end
+    end
+
+    describe "#hash_prepend!" do
+      let(:hash) do
+        { a: 1, b: 2, c: 3 }
+      end
+
+      it "prepend a value at the first position" do
+        subject.hash_prepend!(hash, :a, :d, 4)
+        expect(hash).to eq({ d: 4, a: 1, b: 2, c: 3 })
+      end
+
+      it "prepend a value at the third position" do
+        subject.hash_prepend!(hash, :c, :d, 4)
+        expect(hash).to eq({ a: 1, b: 2, d: 4, c: 3 })
+      end
+
+      context "when key is not found" do
+        it "prepend a value at the last position" do
+          subject.hash_prepend!(hash, :z, :d, 4)
+          expect(hash).to eq({ d: 4, a: 1, b: 2, c: 3 })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of adding option in components (ie proposals) at the end of configuration, insert them where it makes more sense so all support options are grouped or all amendment options are grouped