### PR TITLE
Fix uninitialized constant error with UpdateProposalOverride

### DIFF
--- a/app/commands/concerns/decidim/decidim_awesome/proposals/update_proposal_override.rb
+++ b/app/commands/concerns/decidim/decidim_awesome/proposals/update_proposal_override.rb
@@ -8,7 +8,7 @@ module Decidim
       # to avoid private field to be logged in PaperTrail.
       module UpdateProposalOverride
         extend ActiveSupport::Concern
-        include Admin::UpdateProposalOverride
+        include ::Decidim::DecidimAwesome::Proposals::Admin::UpdateProposalOverride
 
         included do
           private


### PR DESCRIPTION
The error in issue #324 has happened now 3 times to me while working in my development environment and for example running `bin/rails db:setup`.

Making the change from this PR always solved the problem for me.

Last time it happened with 0.11.3