### PR TITLE
prevent hashcash checks on logged users

### DIFF
--- a/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
@@ -30,6 +30,8 @@ module Decidim
 
       # Dynamically configures the gem https://github.com/BaseSecrete/active_hashcash
       def set_hashcash_bits
+        return if user_signed_in?
+
         ActiveHashcash.bits = if controller_name == "registrations"
                                 awesome_hashcash_bits(:signup)
                               else


### PR DESCRIPTION
There are certain situations that the hashcash check activate when the user is already logged in. This was after this fix  #427 