### PR TITLE
Fix access to surveys admin controller

### DIFF
--- a/app/views/layouts/decidim/decidim_awesome/_awesome_config.html.erb
+++ b/app/views/layouts/decidim/decidim_awesome/_awesome_config.html.erb
@@ -19,7 +19,7 @@ window.DecidimAwesome.i18n = {
   "officialAuthor": "<%= j t("decidim.blogs.models.post.fields.official_blog_post") %>",
 }
 window.DecidimAwesome.formBuilderLangsLocation = "<%= decidim_decidim_awesome.form_builder_i18n_path(locale: nil) %>";
-<% if defined?(questionnaire) && questionnaire&.id %>
+<% if defined?(questionnaire) && (questionnaire rescue nil)&.id %>
   window.DecidimAwesome.current_questionnaire = "edit_questionnaire_<%= questionnaire.id %>";
   <% if defined? visitor_already_answered? %>
   window.DecidimAwesome.questionnaire_answered = <%= visitor_already_answered? %>;

--- a/spec/system/admin/admin_edits_surveys_spec.rb
+++ b/spec/system/admin/admin_edits_surveys_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin access to manage a survey" do
+  let(:organization) { create(:organization) }
+  let(:component) do
+    create(:component,
+           manifest_name: "surveys",
+           published_at: nil,
+           organization:)
+  end
+  let!(:questionnaire) { create(:questionnaire) }
+  let!(:survey) { create(:survey, :published, :clean_after_publish, component:, questionnaire:) }
+
+  let!(:user) { create(:user, :admin, :confirmed, organization: component.organization) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  it "allows to manage component" do
+    visit decidim_admin_participatory_processes.decidim_admin_participatory_process_surveys_path(component.participatory_space, component)
+
+    expect(page.evaluate_script("window.DecidimAwesome")).not_to be_nil
+    expect(page.evaluate_script("window.current_questionnaire")).to be_nil
+  end
+end


### PR DESCRIPTION
With the upgrade on #388 we added a bug that wouldn't allow us to enter the admin panel of a survey component.

That was due to the changes in decidim v0.30 and the call of surveys using a `find` instead of a `find_by` that wouldn't throw an error, and this part of the code was relying on that.