### PR TITLE
Correct module defaults link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Decidim::DecidimAwesome.configure do |config|
 end
 ```
 
-For a complete list of options take a look at the [module defaults](lib/decidim/decidim_awesome.rb).
+For a complete list of options take a look at the [module defaults](lib/decidim/decidim_awesome/awesome.rb).
 
 ## Missing something?
 


### PR DESCRIPTION
Config accessors where sent to lib/decidim/decidim_awesome/awesome.rb in a1960bb so I'm just updating the link