### PR TITLE
Fix nil participatory_space error in SpaceConstraintFinder

### DIFF
--- a/app/queries/decidim/decidim_awesome/space_constraint_finder.rb
+++ b/app/queries/decidim/decidim_awesome/space_constraint_finder.rb
@@ -11,6 +11,8 @@ module Decidim
       attr_reader :participatory_space, :config_var
 
       def query
+        return Decidim::DecidimAwesome::AwesomeConfig.none if participatory_space.nil?
+
         set_base_query
         add_space_specific_conditions
       end

--- a/spec/system/admin/assembly_creation_spec.rb
+++ b/spec/system/admin/assembly_creation_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Assembly creation with decidim_awesome constraints" do
+  let(:organization) { create(:organization) }
+  let!(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+  end
+
+  context "when creating a new assembly" do
+    it "does not raise error when accessing assembly creation form" do
+      visit decidim_admin_assemblies.new_assembly_path
+
+      expect(page).to have_content("New assembly")
+
+      expect(page).not_to have_content("undefined method")
+      expect(page).to have_content("New assembly")
+    end
+  end
+end

--- a/spec/system/admin/assembly_creation_spec.rb
+++ b/spec/system/admin/assembly_creation_spec.rb
@@ -16,9 +16,6 @@ describe "Assembly creation with decidim_awesome constraints" do
       visit decidim_admin_assemblies.new_assembly_path
 
       expect(page).to have_content("New assembly")
-
-      expect(page).not_to have_content("undefined method")
-      expect(page).to have_content("New assembly")
     end
   end
 end


### PR DESCRIPTION

This pull request introduces a small but important change to the `SpaceConstraintFinder` query logic. Now, if the `participatory_space` is `nil`, the query will immediately return an empty result set, preventing unnecessary database queries and potential errors.

* Query logic improvement: Added an early return in the `query` method to return `Decidim::DecidimAwesome::AwesomeConfig.none` when `participatory_space` is `nil`.

<img width="537" height="242" alt="image" src="https://github.com/user-attachments/assets/cfeb3297-ced2-49f1-a7c2-8da77756dacd" />

<img width="1394" height="601" alt="image" src="https://github.com/user-attachments/assets/6c97df4e-de31-4105-ba3b-67f4de867f0f" />
