### PR TITLE
Fix check system when module not loaded

### DIFF
--- a/lib/decidim/decidim_awesome/system_checker.rb
+++ b/lib/decidim/decidim_awesome/system_checker.rb
@@ -11,10 +11,9 @@ module Decidim
 
           # rubocop:disable Rails/DynamicFindBy
           checksums = YAML.load_file("#{__dir__}/checksums.yml")
-          loaded_specs = Gem.loaded_specs.keys
 
           @overrides = checksums.filter_map do |package, files|
-            next unless loaded_specs.grep(/#{package}/).any?
+            next unless Decidim::DependencyResolver.instance.needed?(package)
 
             props = {
               spec: ::Gem::Specification.find_by_name(package),

--- a/lib/decidim/decidim_awesome/system_checker.rb
+++ b/lib/decidim/decidim_awesome/system_checker.rb
@@ -11,7 +11,11 @@ module Decidim
 
           # rubocop:disable Rails/DynamicFindBy
           checksums = YAML.load_file("#{__dir__}/checksums.yml")
-          @overrides = checksums.map do |package, files|
+          loaded_specs = Gem.loaded_specs.keys
+
+          @overrides = checksums.filter_map do |package, files|
+            next unless loaded_specs.grep(/#{package}/).any?
+
             props = {
               spec: ::Gem::Specification.find_by_name(package),
               files: files.transform_values(&:values)


### PR DESCRIPTION
As reported in #458 the check system page fails when the `decidim-conferences` module is not loaded in the application.

Since we have the hash of overriden files it was trying to load the module to check the md5 hash, but it failed since the module did not exist.

This change will only show the checks for the modules that have been loaded in the application. Maybe we want to change it so that it also shows modules that can be overriden by `decidim-awesome` but that are not inside the instance.

I would need some review on how to approach this @microstudi 