### PR TITLE
Restric HashCash controllers check on post. Fix variables scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Compatibility:
 
 Fixes:
   - Fix changing locale when Hashcash is active. Make Hashcash respond only to session & registration controllers.
+  - Fix crash when non-installed modules in system checker.
 
 v0.13.1
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Compatibility:
 Fixes:
   - Fix changing locale when Hashcash is active. Make Hashcash respond only to session & registration controllers.
   - Fix crash when non-installed modules in system checker.
+  - Fix some variables not respecting the context where configured (auto_save_forms, validate_caps, etc)
 
 v0.13.1
 -------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+v0.13.2
+-------
+
+Compatibility:
+  - Decidim 0.30.x
+
+Fixes:
+  - Fix changing locale when Hashcash is active
+
 v0.13.1
 -------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Compatibility:
   - Decidim 0.30.x
 
 Fixes:
-  - Fix changing locale when Hashcash is active
+  - Fix changing locale when Hashcash is active. Make Hashcash respond only to session & registration controllers.
 
 v0.13.1
 -------

--- a/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
@@ -30,7 +30,7 @@ module Decidim
 
       # Dynamically configures the gem https://github.com/BaseSecrete/active_hashcash
       def set_hashcash_bits
-        return if Decidim::DecidimAwesome.hashcash_ignored_controllers.include?(controller_name)
+        return unless %w(registrations sessions).include?(controller_name)
         return if user_signed_in?
 
         ActiveHashcash.bits = if controller_name == "registrations"

--- a/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
@@ -30,6 +30,7 @@ module Decidim
 
       # Dynamically configures the gem https://github.com/BaseSecrete/active_hashcash
       def set_hashcash_bits
+        return if Decidim::DecidimAwesome.hashcash_ignored_controllers.include?(controller_name)
         return if user_signed_in?
 
         ActiveHashcash.bits = if controller_name == "registrations"

--- a/app/controllers/decidim/decidim_awesome/admin/menu_hacks_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/menu_hacks_controller.rb
@@ -79,7 +79,7 @@ module Decidim
             position: item.position,
             target: item.try(:target),
             visibility: item.try(:visibility),
-            native?: !item.respond_to?(:overrided?)
+            native?: !item.respond_to?(:overridden?)
           )
         end
 

--- a/app/forms/concerns/decidim/decidim_awesome/proposals/proposal_form_customizations_base.rb
+++ b/app/forms/concerns/decidim/decidim_awesome/proposals/proposal_form_customizations_base.rb
@@ -11,11 +11,11 @@ module Decidim
         end
 
         def minimum_title_length
-          awesome_config.config[:validate_title_min_length].to_i
+          awesome_config.config[:validate_title_min_length].nil? ? awesome_config.defaults[:validate_title_min_length].to_i : awesome_config.config[:validate_title_min_length].to_i
         end
 
         def minimum_body_length
-          awesome_config.config[:validate_body_min_length].to_i
+          awesome_config.config[:validate_body_min_length].nil? ? awesome_config.defaults[:validate_body_min_length].to_i : awesome_config.config[:validate_body_min_length].to_i
         end
 
         def custom_fields

--- a/app/packs/src/decidim/decidim_awesome/forms/autosave.js
+++ b/app/packs/src/decidim/decidim_awesome/forms/autosave.js
@@ -34,7 +34,7 @@ document.addEventListener("DOMContentLoaded", () => {
       '[name="authenticity_token"]',
       "[disabled]",
       // there are problems with matrix questions
-      '[type="checkbox"]'
+      // '[type="checkbox"]'
     ]
   });
 

--- a/app/packs/src/decidim/decidim_awesome/forms/autosave.js
+++ b/app/packs/src/decidim/decidim_awesome/forms/autosave.js
@@ -32,9 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
       // '[type="hidden"]',
       '[name="utf8"]',
       '[name="authenticity_token"]',
-      "[disabled]",
-      // there are problems with matrix questions
-      // '[type="checkbox"]'
+      "[disabled]"
     ]
   });
 

--- a/app/presenters/concerns/decidim/decidim_awesome/menu_item_presenter_override.rb
+++ b/app/presenters/concerns/decidim/decidim_awesome/menu_item_presenter_override.rb
@@ -25,7 +25,7 @@ module Decidim
         end
 
         def hacked_not_overriding?
-          !(@menu_item.is_a?(Decidim::MenuItem) || @menu_item.overrided?)
+          !(@menu_item.is_a?(Decidim::MenuItem) || @menu_item.overridden?)
         end
       end
     end

--- a/app/validators/concerns/decidim/decidim_awesome/etiquette_validator_override.rb
+++ b/app/validators/concerns/decidim/decidim_awesome/etiquette_validator_override.rb
@@ -22,7 +22,6 @@ module Decidim
                     else
                       awesome_config.to_f
                     end
-
           return if value.scan(/[[:upper:]]/).length < value.length * percent / 100
 
           record.errors.add(attribute, options[:message] || I18n.t("too_much_caps", scope: "decidim.decidim_awesome.validators", percent: percent.round))

--- a/app/views/decidim/decidim_awesome/admin/menu_hacks/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/menu_hacks/index.html.erb
@@ -18,7 +18,7 @@
     </thead>
     <tbody>
       <% current_items.each do |item| %>
-        <tr<%= " class=menu_hack-addition" if item.try(:overrided?) == false %>>
+        <tr<%= " class=menu_hack-addition" if item.try(:overridden?) == false %>>
           <td><%= item.label %></td>
           <td><%= item.url %></td>
           <td><%= item.position %></td>
@@ -26,8 +26,8 @@
           <td><%= visibility_options.invert[item.try(:visibility)] %></td>
           <td class="table-list__actions">
             <%= icon_link_to "pencil-line", decidim_admin_decidim_awesome.edit_menu_hack_path(params[:menu_id], md5(item.url)), t(".edit"), class: "action-icon--edit" %>
-            <% if item.respond_to?(:overrided?) %>
-              <%= icon_link_to "close-circle-line", decidim_admin_decidim_awesome.menu_hack_path(params[:menu_id], md5(item.url)), t(".remove#{"_hack" if item.overrided?}"), method: :delete, class: "action-icon--remove", data: { confirm: t(".confirm_destroy") } %>
+            <% if item.respond_to?(:overridden?) %>
+              <%= icon_link_to "close-circle-line", decidim_admin_decidim_awesome.menu_hack_path(params[:menu_id], md5(item.url)), t(".remove#{"_hack" if item.overridden?}"), method: :delete, class: "action-icon--remove", data: { confirm: t(".confirm_destroy") } %>
             <% else %>
                 <span class="action-icon">
                   <%= icon "close-circle-line", class: "action-icon action-icon--disabled", role: "img" %>

--- a/lib/decidim/decidim_awesome/awesome.rb
+++ b/lib/decidim/decidim_awesome/awesome.rb
@@ -154,12 +154,6 @@ module Decidim
       16
     end
 
-    # Controllers that will be ignored when setting hashcash bits
-    # By default, the locales controller is ignored to avoid issues when changing the locale in the
-    config_accessor :hashcash_ignored_controllers do
-      ["locales"]
-    end
-
     # allows admins to created specific CSS snippets affecting only some public frontend specific parts
     # Valid values differ a little from the previous convention:
     #   :disabled => false and non available, hidden from admins

--- a/lib/decidim/decidim_awesome/awesome.rb
+++ b/lib/decidim/decidim_awesome/awesome.rb
@@ -154,6 +154,12 @@ module Decidim
       16
     end
 
+    # Controllers that will be ignored when setting hashcash bits
+    # By default, the locales controller is ignored to avoid issues when changing the locale in the
+    config_accessor :hashcash_ignored_controllers do
+      ["locales"]
+    end
+
     # allows admins to created specific CSS snippets affecting only some public frontend specific parts
     # Valid values differ a little from the previous convention:
     #   :disabled => false and non available, hidden from admins

--- a/lib/decidim/decidim_awesome/engine.rb
+++ b/lib/decidim/decidim_awesome/engine.rb
@@ -113,7 +113,7 @@ module Decidim
 
         # Late registering of components to take into account initializer values
         DecidimAwesome.registered_components.each do |manifest, block|
-          next if DecidimAwesome.disabled_components.include?(manifest)
+          next if DecidimAwesome.disabled_components&.include?(manifest)
           next if Decidim.find_component_manifest(manifest)
 
           Decidim.register_component(manifest, &block)

--- a/lib/decidim/decidim_awesome/map_component/engine.rb
+++ b/lib/decidim/decidim_awesome/map_component/engine.rb
@@ -16,7 +16,7 @@ module Decidim
 
         initializer "decidim_decidim_awesome.content_blocks" do |_app|
           # do not register this if awesome_map is disabled
-          next if DecidimAwesome.disabled_components.include?(:awesome_map)
+          next if DecidimAwesome.disabled_components&.include?(:awesome_map)
 
           # === Home Map block ===
           Decidim.content_blocks.register(:homepage, :awesome_map) do |content_block|

--- a/lib/decidim/decidim_awesome/menu_hacker.rb
+++ b/lib/decidim/decidim_awesome/menu_hacker.rb
@@ -20,7 +20,7 @@ module Decidim
         menu_overrides.each do |item|
           default = default_items.find { |i| i.url.gsub(/\?.*/, "") == item.url }
           if default
-            item.send("overrided?=", true)
+            item.send("overridden?=", true)
             item[:original_active] = default.active
             @items.reject! { |i| i.url.gsub(/\?.*/, "") == item.url }
           end
@@ -58,7 +58,7 @@ module Decidim
             visibility: item["visibility"],
             visible?: visible?(item),
             target: item["target"],
-            overrided?: false
+            overridden?: false
           )
         end
       end

--- a/lib/decidim/decidim_awesome/test/shared_examples/proposal_form_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/proposal_form_examples.rb
@@ -40,6 +40,7 @@ shared_context "with a custom fields enabled" do
   let!(:private_constraint) { create(:config_constraint, awesome_config: private_config_helper, settings: { "participatory_space_manifest" => "participatory_processes" }) }
   let(:slug) { participatory_space.slug }
 end
+
 shared_examples "starts with caps" do |prop|
   let!(:config) { create(:awesome_config, organization:, var: "validate_#{prop}_start_with_caps", value: enabled) }
   let!(:constraint) do
@@ -138,7 +139,7 @@ shared_examples "max caps percent" do |prop|
   context "when scoped under different context" do
     let(:slug) { "another-slug" }
 
-    it_behaves_like "invalid percentage", 25
+    it_behaves_like "invalid percentage", 50
 
     context "when has less than 25% caps" do
       let(prop.to_sym) { "Í only have some CÁPS" }

--- a/lib/decidim/decidim_awesome/test/shared_examples/scoped_admins_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/scoped_admins_examples.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-welcome_text = "Dashboard"
-
 shared_examples "redirects to index" do |_link|
   it "display index page" do
     expect(page).to have_content("You are not authorized to perform this action")
-    expect(page).to have_content(welcome_text)
+    expect(page).to have_content("Dashboard")
     expect(page).to have_current_path(decidim_admin.root_path, ignore_query: true)
   end
 end
@@ -111,12 +109,12 @@ shared_examples "allows all admin routes" do
     visit decidim_admin.root_path
     # this is a workaround to wait for the page to load
     # it seems that the test might fail randomly otherwise
-    # underlaying issue is unknown, maybe capybara is faster clicking than ruby is at storing class variables?
+    # underlying issue is unknown, maybe capybara is faster clicking than ruby is at storing class variables?
     sleep 0.1
   end
 
   it "allows the admin root page" do
-    expect(page).to have_content(welcome_text)
+    expect(page).to have_content("Dashboard")
   end
 
   it "allows the assemblies page" do
@@ -138,7 +136,7 @@ shared_examples "allows scoped admin routes" do
   end
 
   it "allows the admin root page" do
-    expect(page).to have_content(welcome_text)
+    expect(page).to have_content("Dashboard")
   end
 
   it "allows the assemblies page" do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -148,12 +148,12 @@ module Decidim::DecidimAwesome
 
         it "affects configuration evaluation for logged users" do
           subject.application_context!(current_user:)
-          expect(subject.config[:allow_images_in_editors]).to be(true)
+          expect(subject.config[:allow_images_in_editors]).to be_present
         end
 
         it "affects configuration evaluation for anonymous users" do
           subject.application_context!(current_user: nil)
-          expect(subject.config[:allow_images_in_editors]).to be(false)
+          expect(subject.config[:allow_images_in_editors]).to be_blank
         end
       end
     end
@@ -185,8 +185,8 @@ module Decidim::DecidimAwesome
         it "returns the config normalized" do
           expect(subject.config[:intergram_for_public_settings][:chat_id]).to eq("-1234")
           expect(subject.config[:intergram_for_public_settings][:color]).to eq("red")
-          expect(subject.config[:intergram_for_public_settings][:require_login]).to be(true)
-          expect(subject.config[:intergram_for_public_settings][:use_floating_button]).to be(true)
+          expect(subject.config[:intergram_for_public_settings][:require_login]).to be_present
+          expect(subject.config[:intergram_for_public_settings][:use_floating_button]).to be_present
         end
       end
     end
@@ -201,7 +201,7 @@ module Decidim::DecidimAwesome
       let!(:awesome_config) { create(:awesome_config, organization:, var: :allow_images_in_editors, value: true) }
 
       it "always defaults to false" do
-        expect(subject.config[:allow_images_in_editors]).to be(false)
+        expect(subject.config[:allow_images_in_editors]).to be_blank
       end
     end
 
@@ -240,18 +240,21 @@ module Decidim::DecidimAwesome
       end
 
       it "matches customized config" do
-        expect(subject.config).to eq(custom_config)
+        expect(subject.config[:allow_images_in_proposals]).to be_falsey
+        expect(subject.config[:allow_images_in_editors]).to be_truthy
       end
 
       context "and no constraints matches context" do
         let(:slug) { "another-slug" }
 
         it "matches basic config" do
-          expect(subject.config).to eq(config)
+          expect(subject.config[:allow_images_in_editors]).to be_falsey
+          expect(subject.config[:allow_images_in_proposals]).to be_falsey
         end
 
         it "differs from customized config" do
-          expect(subject.config).not_to eq(custom_config)
+          expect(subject.config[:allow_images_in_editors]).not_to eq(custom_config[:allow_images_in_editors])
+          expect(subject.config[:allow_images_in_proposals]).to eq(custom_config[:allow_images_in_proposals])
         end
       end
     end

--- a/spec/system/admin/scoped_admins_spec.rb
+++ b/spec/system/admin/scoped_admins_spec.rb
@@ -6,9 +6,9 @@ require "decidim/decidim_awesome/test/shared_examples/scoped_admins_examples"
 describe "Scoped admin journeys" do
   let(:organization) { create(:organization) }
   let!(:assembly) { create(:assembly, organization:) }
-  let!(:component) { create(:proposal_component, participatory_space: assembly) }
+  let!(:component) { create(:proposal_component, participatory_space: assembly, default_step_settings: { creation_enabled: true }) }
   let!(:proposal) { create(:proposal, :official, component:) }
-  let!(:another_component) { create(:meeting_component, participatory_space: assembly) }
+  let!(:another_component) { create(:meeting_component, participatory_space: assembly, default_step_settings: { creation_enabled: true }) }
   let!(:another_assembly) { create(:assembly, organization:) }
   let!(:participatory_process) { create(:participatory_process, organization:) }
   let!(:process_group) { create(:participatory_process_group, organization:) }
@@ -40,8 +40,8 @@ describe "Scoped admin journeys" do
         end
     end
 
-    component.update!(default_step_settings: { creation_enabled: true })
-    another_component.update!(default_step_settings: { creation_enabled: true })
+    Decidim::User.awesome_potential_admins = []
+    Decidim::User.awesome_admins_for_current_scope = []
     switch_to_host(organization.host)
     login_as user, scope: :user
   end
@@ -73,14 +73,13 @@ describe "Scoped admin journeys" do
 
     context "and admin terms not accepted" do
       it "allows admin terms to be accepted" do
-        welcome_text = "Dashboard"
         visit decidim_admin.root_path
 
         expect(page).to have_content("Please take a moment to review the admin terms of service.")
 
         click_link_or_button "I agree with the terms"
 
-        expect(page).to have_content(welcome_text)
+        expect(page).to have_content("Dashboard")
         expect(page).to have_no_content("Please take a moment to review the admin terms of service.")
       end
     end

--- a/spec/system/admin/scoped_admins_spec.rb
+++ b/spec/system/admin/scoped_admins_spec.rb
@@ -43,113 +43,128 @@ describe "Scoped admin journeys" do
     Decidim::User.awesome_potential_admins = []
     Decidim::User.awesome_admins_for_current_scope = []
     switch_to_host(organization.host)
-    login_as user, scope: :user
   end
 
-  context "when is not a scoped admin" do
-    it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_admin.root_path }
-    end
-  end
-
-  context "when is a scoped admin" do
-    let(:admins) do
-      {
-        "bar" => [user.id.to_s]
-      }
+  context "when logged as user" do
+    before do
+      login_as user, scope: :user
     end
 
-    context "and scope is 'none'" do
-      let(:settings) do
-        {
-          "participatory_space_manifest" => "none"
-        }
-      end
-
+    context "when is not a scoped admin" do
       it_behaves_like "a 404 page" do
         let(:target_path) { decidim_admin.root_path }
       end
     end
 
-    context "and admin terms not accepted" do
-      it "allows admin terms to be accepted" do
-        visit decidim_admin.root_path
-
-        expect(page).to have_content("Please take a moment to review the admin terms of service.")
-
-        click_link_or_button "I agree with the terms"
-
-        expect(page).to have_content("Dashboard")
-        expect(page).to have_no_content("Please take a moment to review the admin terms of service.")
+    context "when is a scoped admin" do
+      let(:admins) do
+        {
+          "bar" => [user.id.to_s]
+        }
       end
-    end
 
-    context "and admin terms are accepted" do
-      let(:user) { user_accepted }
-
-      it_behaves_like "allows all admin routes"
-      it_behaves_like "allows external accesses"
-      it_behaves_like "forbids awesome access"
-      it_behaves_like "edits all assemblies"
-
-      context "and there's constraints" do
+      context "and scope is 'none'" do
         let(:settings) do
           {
-            "participatory_space_manifest" => "assemblies",
-            "participatory_space_slug" => assembly.slug
+            "participatory_space_manifest" => "none"
           }
         end
 
-        it_behaves_like "allows scoped admin routes"
-        it_behaves_like "shows partial admin links in the frontend"
-        it_behaves_like "edits allowed assemblies"
-
-        context "and user is a real admin" do
-          let(:user) { admin }
-
-          it_behaves_like "allows all admin routes"
-          it_behaves_like "allows external accesses"
-          it_behaves_like "allows awesome access"
-          it_behaves_like "edits all assemblies"
+        it_behaves_like "a 404 page" do
+          let(:target_path) { decidim_admin.root_path }
         end
+      end
 
-        context "and scoped to a component" do
-          let(:settings) do
-            {
-              "participatory_space_manifest" => "assemblies",
-              "participatory_space_slug" => assembly.slug,
-              "component_manifest" => "proposals"
-            }
-          end
+      context "and admin terms not accepted" do
+        it "allows admin terms to be accepted" do
+          visit decidim_admin.root_path
 
-          it_behaves_like "allows scoped admin routes"
-          it_behaves_like "shows component partial admin links in the frontend"
-          it_behaves_like "edits allowed components"
-        end
+          expect(page).to have_content("Please take a moment to review the admin terms of service.")
 
-        context "and scoped to any process group" do
-          let(:settings) do
-            {
-              "participatory_space_manifest" => "process_groups"
-            }
-          end
+          click_link_or_button "I agree with the terms"
 
-          it_behaves_like "allows access to group processes"
-          it_behaves_like "allows edit any group process"
-        end
-
-        context "and scoped to a specific processes group" do
-          let(:settings) do
-            {
-              "participatory_space_manifest" => "process_groups",
-              "participatory_space_slug" => process_group.id
-            }
-          end
-
-          it_behaves_like "allows access to group processes"
-          it_behaves_like "allows edit only allowed group process"
+          expect(page).to have_content("Dashboard")
+          expect(page).to have_no_content("Please take a moment to review the admin terms of service.")
         end
       end
     end
+  end
+
+  context "when login with admin terms are accepted" do
+    let(:admins) do
+      {
+        "bar" => [user_accepted.id.to_s]
+      }
+    end
+
+    before do
+      login_as user_accepted, scope: :user
+    end
+
+    it_behaves_like "allows all admin routes"
+    it_behaves_like "allows external accesses"
+    it_behaves_like "forbids awesome access"
+    it_behaves_like "edits all assemblies"
+
+    context "and there's constraints" do
+      let(:settings) do
+        {
+          "participatory_space_manifest" => "assemblies",
+          "participatory_space_slug" => assembly.slug
+        }
+      end
+
+      it_behaves_like "allows scoped admin routes"
+      it_behaves_like "shows partial admin links in the frontend"
+      it_behaves_like "edits allowed assemblies"
+    end
+
+    context "and scoped to a component" do
+      let(:settings) do
+        {
+          "participatory_space_manifest" => "assemblies",
+          "participatory_space_slug" => assembly.slug,
+          "component_manifest" => "proposals"
+        }
+      end
+
+      it_behaves_like "allows scoped admin routes"
+      it_behaves_like "shows component partial admin links in the frontend"
+      it_behaves_like "edits allowed components"
+    end
+
+    context "and scoped to any process group" do
+      let(:settings) do
+        {
+          "participatory_space_manifest" => "process_groups"
+        }
+      end
+
+      it_behaves_like "allows access to group processes"
+      it_behaves_like "allows edit any group process"
+    end
+
+    context "and scoped to a specific processes group" do
+      let(:settings) do
+        {
+          "participatory_space_manifest" => "process_groups",
+          "participatory_space_slug" => process_group.id
+        }
+      end
+
+      it_behaves_like "allows access to group processes"
+      it_behaves_like "allows edit only allowed group process"
+    end
+  end
+
+  context "when login as a real admin" do
+    before do
+      login_as admin, scope: :user
+    end
+
+    it_behaves_like "allows all admin routes"
+    it_behaves_like "allows external accesses"
+    it_behaves_like "allows awesome access"
+    it_behaves_like "edits all assemblies"
   end
 end

--- a/spec/system/public/hashcash_forms_spec.rb
+++ b/spec/system/public/hashcash_forms_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe "Hashcash protector", :perform_enqueued do
-  let(:organization) { create(:organization, available_locales: [:en]) }
+  let(:organization) { create(:organization, available_locales: [:en, :ca]) }
   let!(:component) { create(:proposal_component, :with_creation_enabled, organization:) }
   let!(:awesome_hashcash_login) { create(:awesome_config, organization:, var: :hashcash_login, value: hashcash_login) }
   let!(:awesome_hashcash_signup) { create(:awesome_config, organization:, var: :hashcash_signup, value: hashcash_signup) }
@@ -38,6 +38,14 @@ describe "Hashcash protector", :perform_enqueued do
   context "when not logged in" do
     before do
       visit decidim.new_user_session_path
+    end
+
+    it "can change language" do
+      within_language_menu do
+        click_on "Català"
+      end
+      expect(page).to have_content("Entra")
+      expect(page).to have_content("El meu compte")
     end
 
     context "when the user logs_in in session controller" do

--- a/spec/system/public/home_content_block_menu_hacks_spec.rb
+++ b/spec/system/public/home_content_block_menu_hacks_spec.rb
@@ -33,84 +33,103 @@ describe "Hacked home content block menu" do
     disabled_features.each do |feature|
       allow(Decidim::DecidimAwesome.config).to receive(feature).and_return(:disabled)
     end
-
-    switch_to_host(organization.host)
-    visit decidim.root_path
   end
 
-  it "renders the hacked menu" do
-    within "#home__menu" do
-      expect(page).to have_no_content("Processes")
-      expect(page).to have_content("Mastering projects")
-      expect(page).to have_content("Blog")
-    end
-  end
-
-  it "renders in the proper order" do
-    within "#home__menu div.home__menu-element:nth-child(1)" do
-      expect(page).to have_content("Blog")
-    end
-    within "#home__menu div.home__menu-element:last-child" do
-      expect(page).to have_content("Mastering projects")
-    end
-  end
-
-  describe "visibility" do
-    let(:visibility) { "default" }
-    let(:overridden) do
-      {
-        url: "/processes",
-        label: {
-          "en" => "Mastering projects"
-        },
-        position: 10,
-        visibility:
-      }
+  context "when not logged in" do
+    before do
+      switch_to_host(organization.host)
+      visit decidim.root_path
     end
 
-    it "renders the item" do
+    it "renders the hacked menu" do
       within "#home__menu" do
+        expect(page).to have_no_content("Processes")
+        expect(page).to have_content("Mastering projects")
+        expect(page).to have_content("Blog")
+      end
+    end
+
+    it "renders in the proper order" do
+      within "#home__menu div.home__menu-element:nth-child(1)" do
+        expect(page).to have_content("Blog")
+      end
+      within "#home__menu div.home__menu-element:last-child" do
         expect(page).to have_content("Mastering projects")
       end
     end
 
-    context "when hidden" do
-      let(:visibility) { "hidden" }
-
-      it "do not show the menu item" do
-        within "#home__menu" do
-          expect(page).to have_no_content("Mastering projects")
-        end
+    describe "visibility" do
+      let(:visibility) { "default" }
+      let(:overridden) do
+        {
+          url: "/processes",
+          label: {
+            "en" => "Mastering projects"
+          },
+          position: 10,
+          visibility:
+        }
       end
-    end
 
-    context "when logged" do
-      let(:visibility) { "logged" }
-
-      it "do not show the menu item" do
-        within "#home__menu" do
-          expect(page).to have_no_content("Mastering projects")
-        end
-      end
-    end
-
-    context "when non logged" do
-      let(:visibility) { "non_logged" }
-
-      it "do not show the menu item" do
+      it "renders the item" do
         within "#home__menu" do
           expect(page).to have_content("Mastering projects")
         end
       end
+
+      context "when hidden" do
+        let(:visibility) { "hidden" }
+
+        it "do not show the menu item" do
+          within "#home__menu" do
+            expect(page).to have_no_content("Mastering projects")
+          end
+        end
+      end
+
+      context "when logged" do
+        let(:visibility) { "logged" }
+
+        it "do not show the menu item" do
+          within "#home__menu" do
+            expect(page).to have_no_content("Mastering projects")
+          end
+        end
+      end
+
+      context "when non logged" do
+        let(:visibility) { "non_logged" }
+
+        it "do not show the menu item" do
+          within "#home__menu" do
+            expect(page).to have_content("Mastering projects")
+          end
+        end
+      end
+    end
+  end
+
+  context "when user is logged" do
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let!(:authorization) { create(:authorization, granted_at: Time.zone.now, user:, name: "dummy_authorization_handler") }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim.root_path
     end
 
-    context "when user is logged" do
-      let!(:user) { create(:user, :confirmed, organization:) }
-
-      before do
-        switch_to_host(organization.host)
-        login_as user, scope: :user
-        visit decidim.root_path
+    describe "visibility" do
+      let(:visibility) { "default" }
+      let(:overridden) do
+        {
+          url: "/processes",
+          label: {
+            "en" => "Mastering projects"
+          },
+          position: 10,
+          visibility:
+        }
       end
 
       context "when hidden" do
@@ -145,14 +164,7 @@ describe "Hacked home content block menu" do
 
       context "when only verified user" do
         let!(:available_authorizations) { ["dummy_authorization_handler"] }
-        let!(:authorization) { create(:authorization, granted_at: Time.zone.now, user:, name: "dummy_authorization_handler") }
         let(:visibility) { "verified_user" }
-
-        before do
-          switch_to_host(organization.host)
-          login_as user, scope: :user
-          visit decidim.root_path
-        end
 
         context "when user is verified" do
           it "shows the item" do

--- a/spec/system/public/home_content_block_menu_hacks_spec.rb
+++ b/spec/system/public/home_content_block_menu_hacks_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 describe "Hacked home content block menu" do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, available_authorizations:) }
+  let(:available_authorizations) { [] }
   let!(:participatory_process) { create(:participatory_process, organization:) }
   let!(:config) { create(:awesome_config, organization:, var: :home_content_block_menu, value: menu) }
   let(:menu) { [overridden, added] }
@@ -142,7 +143,8 @@ describe "Hacked home content block menu" do
         end
       end
 
-      context "when only verified user", with_authorization_workflows: ["dummy_authorization_handler"] do
+      context "when only verified user" do
+        let!(:available_authorizations) { ["dummy_authorization_handler"] }
         let!(:authorization) { create(:authorization, granted_at: Time.zone.now, user:, name: "dummy_authorization_handler") }
         let(:visibility) { "verified_user" }
 

--- a/spec/system/public/menu_hacks_spec.rb
+++ b/spec/system/public/menu_hacks_spec.rb
@@ -3,7 +3,8 @@
 require "spec_helper"
 
 describe "Hacked menus" do
-  let(:organization) { create(:organization) }
+  let(:organization) { create(:organization, available_authorizations:) }
+  let(:available_authorizations) { [] }
   let!(:participatory_process) { create(:participatory_process, organization:) }
   let!(:config) { create(:awesome_config, organization:, var: :menu, value: menu) }
   let(:menu) { [overridden, added] }
@@ -31,10 +32,6 @@ describe "Hacked menus" do
     disabled_features.each do |feature|
       allow(Decidim::DecidimAwesome.config).to receive(feature).and_return(:disabled)
     end
-
-    switch_to_host(organization.host)
-    visit decidim_participatory_processes.participatory_processes_path
-    find_by_id("main-dropdown-summary").hover
   end
 
   shared_examples "has active link" do |text|
@@ -44,110 +41,77 @@ describe "Hacked menus" do
       end
     end
 
-    it "active link containts text" do
+    it "active link contains text" do
       within "#main-dropdown-menu .active" do
         expect(page).to have_content(text)
       end
     end
   end
 
-  it "renders the hacked menu" do
-    within "#main-dropdown-menu" do
-      expect(page).to have_no_content("Home")
-      expect(page).to have_content("Processes")
-      expect(page).to have_content("A new beginning")
-      expect(page).to have_content("Blog")
-    end
-  end
-
-  it "renders in the proper order" do
-    within "#main-dropdown-menu li:nth-child(1)" do
-      expect(page).to have_content("Processes")
-    end
-    within "#main-dropdown-menu li:nth-child(2)" do
-      expect(page).to have_content("Blog")
-    end
-    within "#main-dropdown-menu li:last-child" do
-      expect(page).to have_content("A new beginning")
-    end
-  end
-
-  context "when opens in a new window" do
-    let(:added) do
-      {
-        url: "http://external.blog",
-        label: {
-          "en" => "Blog"
-        },
-        position: 9,
-        target: "_blank"
-      }
+  context "when not logged in" do
+    before do
+      switch_to_host(organization.host)
+      visit decidim_participatory_processes.participatory_processes_path
+      find_by_id("main-dropdown-summary").hover
     end
 
-    it "has target blank" do
-      expect(find("#main-dropdown-menu li:nth-child(2) a")["data-remote"]).to eq("true")
-      expect(find("#main-dropdown-menu li:nth-child(2) a")[:target]).to eq("_blank")
-      expect(find("#main-dropdown-menu li:last-child a")["data-remote"]).not_to eq("true")
-    end
-  end
-
-  describe "visibility" do
-    let(:visibility) { "default" }
-    let(:overridden) do
-      {
-        url: "/",
-        label: {
-          "en" => "A new beginning"
-        },
-        position: 10,
-        visibility:
-      }
-    end
-
-    it "renders the item" do
+    it "renders the hacked menu" do
       within "#main-dropdown-menu" do
+        expect(page).to have_no_content("Home")
+        expect(page).to have_content("Processes")
+        expect(page).to have_content("A new beginning")
+        expect(page).to have_content("Blog")
+      end
+    end
+
+    it "renders in the proper order" do
+      within "#main-dropdown-menu li:nth-child(1)" do
+        expect(page).to have_content("Processes")
+      end
+      within "#main-dropdown-menu li:nth-child(2)" do
+        expect(page).to have_content("Blog")
+      end
+      within "#main-dropdown-menu li:last-child" do
         expect(page).to have_content("A new beginning")
       end
     end
 
-    context "when hidden" do
-      let(:visibility) { "hidden" }
+    context "when opens in a new window" do
+      let(:added) do
+        {
+          url: "http://external.blog",
+          label: {
+            "en" => "Blog"
+          },
+          position: 9,
+          target: "_blank"
+        }
+      end
 
-      it "do not show the menu item" do
-        within "#main-dropdown-menu" do
-          expect(page).to have_no_content("A new beginning")
-        end
+      it "has target blank" do
+        expect(find("#main-dropdown-menu li:nth-child(2) a")["data-remote"]).to eq("true")
+        expect(find("#main-dropdown-menu li:nth-child(2) a")[:target]).to eq("_blank")
+        expect(find("#main-dropdown-menu li:last-child a")["data-remote"]).not_to eq("true")
       end
     end
 
-    context "when logged" do
-      let(:visibility) { "logged" }
-
-      it "do not show the menu item" do
-        within "#main-dropdown-menu" do
-          expect(page).to have_no_content("A new beginning")
-        end
+    describe "visibility" do
+      let(:visibility) { "default" }
+      let(:overridden) do
+        {
+          url: "/",
+          label: {
+            "en" => "A new beginning"
+          },
+          position: 10,
+          visibility:
+        }
       end
-    end
 
-    context "when non logged" do
-      let(:visibility) { "non_logged" }
-
-      it "do not show the menu item" do
+      it "renders the item" do
         within "#main-dropdown-menu" do
           expect(page).to have_content("A new beginning")
         end
-      end
-    end
-
-    context "when user is logged" do
-      let!(:user) { create(:user, :confirmed, organization:) }
-
-      before do
-        switch_to_host(organization.host)
-        login_as user, scope: :user
-        visit decidim_participatory_processes.participatory_processes_path
-        find_by_id("main-dropdown-summary").hover
       end
 
       context "when hidden" do
@@ -165,7 +129,7 @@ describe "Hacked menus" do
 
         it "do not show the menu item" do
           within "#main-dropdown-menu" do
-            expect(page).to have_content("A new beginning")
+            expect(page).to have_no_content("A new beginning")
           end
         end
       end
@@ -175,135 +139,181 @@ describe "Hacked menus" do
 
         it "do not show the menu item" do
           within "#main-dropdown-menu" do
-            expect(page).to have_no_content("A new beginning")
+            expect(page).to have_content("A new beginning")
           end
         end
       end
+    end
 
-      context "when only verified user", with_authorization_workflows: ["dummy_authorization_handler"] do
-        let!(:authorization) { create(:authorization, granted_at: Time.zone.now, user:, name: "dummy_authorization_handler") }
-        let(:visibility) { "verified_user" }
+    context "when menu is :disabled" do
+      let(:disabled_features) { [:menu] }
 
+      it "renders the normal menu" do
+        within "#main-dropdown-menu" do
+          expect(page).to have_content("Home")
+          expect(page).to have_content("Processes")
+          expect(page).to have_no_content("A new beginning")
+          expect(page).to have_no_content("Blog")
+        end
+      end
+
+      it_behaves_like "has active link", "Processes"
+    end
+
+    describe "active" do
+      let!(:component) { create(:proposal_component, participatory_space: participatory_process) }
+      let!(:participatory_process2) { create(:participatory_process, organization:) }
+      let!(:component2) { create(:proposal_component, participatory_space: participatory_process2) }
+      let(:menu) do
+        [
+          {
+            url: "/processes",
+            label: {
+              "en" => "A new beginning"
+            },
+            position: 1
+          },
+          {
+            url: "/processes/#{participatory_process.slug}",
+            label: {
+              "en" => "A single process"
+            },
+            position: 2
+          }
+        ]
+      end
+
+      it_behaves_like "has active link", "A new beginning"
+
+      context "when visiting all processes list" do
         before do
-          switch_to_host(organization.host)
-          login_as user, scope: :user
           visit decidim_participatory_processes.participatory_processes_path
           find_by_id("main-dropdown-summary").hover
         end
 
-        context "when user is verified" do
-          it "shows the item" do
-            within "#main-dropdown-menu" do
-              expect(page).to have_content("A new beginning")
-            end
-          end
-        end
-
-        context "when user is not verified" do
-          let(:authorization) { nil }
-
-          it "shows the item" do
-            within "#main-dropdown-menu" do
-              expect(page).to have_no_content("A new beginning")
-            end
-          end
-        end
-
-        context "when verification is expired" do
-          let!(:authorization) { create(:authorization, granted_at: 3.months.ago, user:, name: "dummy_authorization_handler") }
-
-          it "shows the item" do
-            within "#main-dropdown-menu" do
-              expect(page).to have_no_content("A new beginning")
-            end
-          end
-        end
+        it_behaves_like "has active link", "A new beginning"
       end
 
-      describe "active" do
-        let!(:component) { create(:proposal_component, participatory_space: participatory_process) }
-        let!(:participatory_process2) { create(:participatory_process, organization:) }
-        let!(:component2) { create(:proposal_component, participatory_space: participatory_process2) }
-        let(:menu) do
-          [
-            {
-              url: "/processes",
-              label: {
-                "en" => "A new beginning"
-              },
-              position: 1
-            },
-            {
-              url: "/processes/#{participatory_process.slug}",
-              label: {
-                "en" => "A single process"
-              },
-              position: 2
-            }
-          ]
+      context "when visiting a process in a custom link" do
+        before do
+          visit decidim_participatory_processes.participatory_process_path(participatory_process.slug)
+          find_by_id("main-dropdown-summary").hover
+        end
+
+        it_behaves_like "has active link", "A single process"
+      end
+
+      context "when visiting a sublink of a process in a custom link" do
+        before do
+          visit main_component_path(component)
+          find_by_id("main-dropdown-summary").hover
+        end
+
+        it_behaves_like "has active link", "A single process"
+      end
+
+      context "when visiting a process not in a custom link" do
+        before do
+          visit decidim_participatory_processes.participatory_process_path(participatory_process2.slug)
+          find_by_id("main-dropdown-summary").hover
         end
 
         it_behaves_like "has active link", "A new beginning"
+      end
 
-        context "when visiting all processes list" do
-          before do
-            visit decidim_participatory_processes.participatory_processes_path
-            find_by_id("main-dropdown-summary").hover
-          end
-
-          it_behaves_like "has active link", "A new beginning"
+      context "when visiting a sublink of a process not in a custom link" do
+        before do
+          visit main_component_path(component2)
+          find_by_id("main-dropdown-summary").hover
         end
 
-        context "when visiting a process in a custom link" do
-          before do
-            visit decidim_participatory_processes.participatory_process_path(participatory_process.slug)
-            find_by_id("main-dropdown-summary").hover
-          end
+        it_behaves_like "has active link", "A new beginning"
+      end
+    end
+  end
 
-          it_behaves_like "has active link", "A single process"
+  context "when user is logged" do
+    let!(:user) { create(:user, :confirmed, organization:) }
+    let!(:authorization) { create(:authorization, granted_at: Time.zone.now, user:, name: "dummy_authorization_handler") }
+    let(:visibility) { "default" }
+    let(:overridden) do
+      {
+        url: "/",
+        label: {
+          "en" => "A new beginning"
+        },
+        position: 10,
+        visibility:
+      }
+    end
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_participatory_processes.participatory_processes_path
+      find_by_id("main-dropdown-summary").hover
+    end
+
+    context "when hidden" do
+      let(:visibility) { "hidden" }
+
+      it "do not show the menu item" do
+        within "#main-dropdown-menu" do
+          expect(page).to have_no_content("A new beginning")
         end
+      end
+    end
 
-        context "when visiting a sublink of a process in a custom link" do
-          before do
-            visit main_component_path(component)
-            find_by_id("main-dropdown-summary").hover
-          end
+    context "when logged" do
+      let(:visibility) { "logged" }
 
-          it_behaves_like "has active link", "A single process"
+      it "do not show the menu item" do
+        within "#main-dropdown-menu" do
+          expect(page).to have_content("A new beginning")
         end
+      end
+    end
 
-        context "when visiting a process not in a custom link" do
-          before do
-            visit decidim_participatory_processes.participatory_process_path(participatory_process2.slug)
-            find_by_id("main-dropdown-summary").hover
-          end
+    context "when non logged" do
+      let(:visibility) { "non_logged" }
 
-          it_behaves_like "has active link", "A new beginning"
+      it "do not show the menu item" do
+        within "#main-dropdown-menu" do
+          expect(page).to have_no_content("A new beginning")
         end
+      end
+    end
 
-        context "when visiting a sublink of a process not in a custom link" do
-          before do
-            visit main_component_path(component2)
-            find_by_id("main-dropdown-summary").hover
+    context "when only verified user" do
+      let!(:available_authorizations) { ["dummy_authorization_handler"] }
+      let(:visibility) { "verified_user" }
+
+      context "when user is verified" do
+        it "shows the item" do
+          within "#main-dropdown-menu" do
+            expect(page).to have_content("A new beginning")
           end
-
-          it_behaves_like "has active link", "A new beginning"
         end
       end
 
-      context "when menu is :disabled" do
-        let(:disabled_features) { [:menu] }
+      context "when user is not verified" do
+        let(:authorization) { nil }
 
-        it "renders the normal menu" do
+        it "shows the item" do
           within "#main-dropdown-menu" do
-            expect(page).to have_content("Home")
-            expect(page).to have_content("Processes")
             expect(page).to have_no_content("A new beginning")
-            expect(page).to have_no_content("Blog")
           end
         end
+      end
 
-        it_behaves_like "has active link", "Processes"
+      context "when verification is expired" do
+        let!(:authorization) { create(:authorization, granted_at: 3.months.ago, user:, name: "dummy_authorization_handler") }
+
+        it "shows the item" do
+          within "#main-dropdown-menu" do
+            expect(page).to have_no_content("A new beginning")
+          end
+        end
       end
     end
   end

--- a/spec/system/public/questionnaires_spec.rb
+++ b/spec/system/public/questionnaires_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 require "decidim/decidim_awesome/test/shared_examples/config_examples"
 
 describe "Questionnaires" do
+  # rubocop:disable Capybara/SpecificFinders
   include_context "with a component"
   let(:manifest_name) { "meetings" }
 
@@ -14,29 +15,109 @@ describe "Questionnaires" do
   end
 
   let(:meeting) { create(:meeting, :published, :online, :live, component:) }
-  let(:meeting_live_event_path) do
-    decidim_participatory_process_meetings.meeting_live_event_path(
-      participatory_process_slug: participatory_process.slug,
-      component_id: component.id,
-      meeting_id: meeting.id
-    )
+  let(:questionnaire_path) { Decidim::EngineRouter.main_proxy(component).meeting_live_event_path(meeting) }
+
+  before do
+    login_as user, scope: :user
   end
 
   it "does not have current_questionnaire" do
-    login_as user, scope: :user
-    visit meeting_live_event_path
+    visit questionnaire_path
     expect(page.body).to have_no_content("window.DecidimAwesome.current_questionnaire")
   end
 
   context "when questionnaire exist" do
     let!(:poll) { create(:poll, meeting:) }
     let!(:questionnaire) { create(:meetings_poll_questionnaire, questionnaire_for: poll) }
-    let!(:question_single_option) { create(:meetings_poll_question, :unpublished, questionnaire:) }
+    let!(:question_single_option) { create(:meetings_poll_question, :published, questionnaire:) }
 
     it "has current_questionnaire" do
-      login_as user, scope: :user
-      visit meeting_live_event_path
+      visit questionnaire_path
       expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
     end
   end
+
+  context "when surveys" do
+    let(:manifest_name) { "surveys" }
+    let(:survey) { create(:survey, :published, allow_answers: true, component:, questionnaire:) }
+    let(:questionnaire_path) { Decidim::EngineRouter.main_proxy(component).survey_path(survey) }
+    let(:questionnaire) { create(:questionnaire) }
+    let!(:question_single_option) { create(:questionnaire_question, :with_answer_options, question_type: "single_option", questionnaire:) }
+    let!(:question_text) { create(:questionnaire_question, question_type: "short_answer", questionnaire:) }
+
+    it "saves answers in local storage" do
+      visit questionnaire_path
+      expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
+
+      fill_in "questionnaire_responses_1", with: "My answer"
+      choose "questionnaire_responses_0_choices_1_body"
+      sleep 0.1
+
+      visit questionnaire_path
+      sleep 0.1
+
+      expect(find("#questionnaire_responses_1").value).to eq("My answer")
+      expect(find("#questionnaire_responses_0_choices_1_body")).to be_checked
+    end
+
+    context "when awesome config is disabled" do
+      let!(:awesome_config) { create(:awesome_config, organization:, var: :auto_save_forms, value: false) }
+
+      it "does not save answers in local storage" do
+        visit questionnaire_path
+        expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
+
+        fill_in "questionnaire_responses_1", with: "My answer"
+        choose "questionnaire_responses_0_choices_1_body"
+        sleep 0.1
+
+        visit questionnaire_path
+        sleep 0.1
+
+        expect(find("#questionnaire_responses_1").value).to eq("")
+        expect(find("#questionnaire_responses_0_choices_1_body")).not_to be_checked
+      end
+    end
+
+    context "when awesome config is scoped to the current participatory space" do
+      let!(:awesome_config) { create(:awesome_config, organization:, var: :auto_save_forms) }
+      let!(:awesome_constraint) { create(:config_constraint, awesome_config:, settings: { participatory_space_slug: component.participatory_space.slug }) }
+
+      it "saves answers in local storage" do
+        visit questionnaire_path
+        expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
+
+        fill_in "questionnaire_responses_1", with: "My answer"
+        choose "questionnaire_responses_0_choices_1_body"
+        sleep 0.1
+
+        visit questionnaire_path
+        sleep 0.1
+
+        expect(find("#questionnaire_responses_1").value).to eq("My answer")
+        expect(find("#questionnaire_responses_0_choices_1_body")).to be_checked
+      end
+    end
+
+    context "when awesome config is scoped to another participatory space" do
+      let!(:awesome_config) { create(:awesome_config, organization:, var: :auto_save_forms) }
+      let!(:awesome_constraint) { create(:config_constraint, awesome_config:, settings: { participatory_space_slug: "other-slug" }) }
+
+      it "does not save answers in local storage" do
+        visit questionnaire_path
+        expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
+
+        fill_in "questionnaire_responses_1", with: "My answer"
+        choose "questionnaire_responses_0_choices_1_body"
+        sleep 0.1
+
+        visit questionnaire_path
+        sleep 0.1
+
+        expect(find("#questionnaire_responses_1").value).to eq("")
+        expect(find("#questionnaire_responses_0_choices_1_body")).not_to be_checked
+      end
+    end
+  end
+  # rubocop:enable Capybara/SpecificFinders
 end

--- a/spec/system/public/questionnaires_spec.rb
+++ b/spec/system/public/questionnaires_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 require "decidim/decidim_awesome/test/shared_examples/config_examples"
 
 describe "Questionnaires" do
-  # rubocop:disable Capybara/SpecificFinders
   include_context "with a component"
   let(:manifest_name) { "meetings" }
 
@@ -49,15 +48,19 @@ describe "Questionnaires" do
       visit questionnaire_path
       expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
 
-      fill_in "questionnaire_responses_1", with: "My answer"
-      choose "questionnaire_responses_0_choices_1_body"
+      within ".answer-questionnaire__step" do
+        find('input[type="text"]', match: :first).fill_in(with: "My answer")
+        find('input[type="radio"]', match: :first).click
+      end
       sleep 0.1
 
       visit questionnaire_path
       sleep 0.1
 
-      expect(find("#questionnaire_responses_1").value).to eq("My answer")
-      expect(find("#questionnaire_responses_0_choices_1_body")).to be_checked
+      within ".answer-questionnaire__step" do
+        expect(find('input[type="radio"]', match: :first)).to be_checked
+        expect(find('input[type="text"]', match: :first).value).to eq("My answer")
+      end
     end
 
     context "when awesome config is disabled" do
@@ -67,15 +70,19 @@ describe "Questionnaires" do
         visit questionnaire_path
         expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
 
-        fill_in "questionnaire_responses_1", with: "My answer"
-        choose "questionnaire_responses_0_choices_1_body"
+        within ".answer-questionnaire__step" do
+          find('input[type="text"]', match: :first).fill_in(with: "My answer")
+          find('input[type="radio"]', match: :first).click
+        end
         sleep 0.1
 
         visit questionnaire_path
         sleep 0.1
 
-        expect(find("#questionnaire_responses_1").value).to eq("")
-        expect(find("#questionnaire_responses_0_choices_1_body")).not_to be_checked
+        within ".answer-questionnaire__step" do
+          expect(find('input[type="radio"]', match: :first)).not_to be_checked
+          expect(find('input[type="text"]', match: :first).value).to eq("")
+        end
       end
     end
 
@@ -87,15 +94,19 @@ describe "Questionnaires" do
         visit questionnaire_path
         expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
 
-        fill_in "questionnaire_responses_1", with: "My answer"
-        choose "questionnaire_responses_0_choices_1_body"
+        within ".answer-questionnaire__step" do
+          find('input[type="text"]', match: :first).fill_in(with: "My answer")
+          find('input[type="radio"]', match: :first).click
+        end
         sleep 0.1
 
         visit questionnaire_path
         sleep 0.1
 
-        expect(find("#questionnaire_responses_1").value).to eq("My answer")
-        expect(find("#questionnaire_responses_0_choices_1_body")).to be_checked
+        within ".answer-questionnaire__step" do
+          expect(find('input[type="radio"]', match: :first)).to be_checked
+          expect(find('input[type="text"]', match: :first).value).to eq("My answer")
+        end
       end
     end
 
@@ -107,17 +118,20 @@ describe "Questionnaires" do
         visit questionnaire_path
         expect(page.body).to have_content("window.DecidimAwesome.current_questionnaire")
 
-        fill_in "questionnaire_responses_1", with: "My answer"
-        choose "questionnaire_responses_0_choices_1_body"
+        within ".answer-questionnaire__step" do
+          find('input[type="text"]', match: :first).fill_in(with: "My answer")
+          find('input[type="radio"]', match: :first).click
+        end
         sleep 0.1
 
         visit questionnaire_path
         sleep 0.1
 
-        expect(find("#questionnaire_responses_1").value).to eq("")
-        expect(find("#questionnaire_responses_0_choices_1_body")).not_to be_checked
+        within ".answer-questionnaire__step" do
+          expect(find('input[type="radio"]', match: :first)).not_to be_checked
+          expect(find('input[type="text"]', match: :first).value).to eq("")
+        end
       end
     end
   end
-  # rubocop:enable Capybara/SpecificFinders
 end

--- a/spec/validators/etiquette_validator_spec.rb
+++ b/spec/validators/etiquette_validator_spec.rb
@@ -46,6 +46,7 @@ describe EtiquetteValidator do
 
   shared_examples "attribute caps validation" do |attribute|
     context "when #{attribute} has too much caps" do
+      let(:config_helper) { send("validate_#{attribute}_max_caps_percent") }
       let(attribute) { "A SCREAMING PIECE of text" }
 
       it { is_expected.not_to be_valid }

--- a/spec/validators/etiquette_validator_spec.rb
+++ b/spec/validators/etiquette_validator_spec.rb
@@ -3,25 +3,23 @@
 require "spec_helper"
 
 describe EtiquetteValidator do
-  subject { validatable.new(title:, body:) }
+  subject { Validatable.new(title:, body:) }
 
-  let(:validatable) do
-    Class.new do
-      def self.model_name
-        ActiveModel::Name.new(self, nil, "Validatable")
-      end
+  class Validatable
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "Validatable")
+    end
 
-      include Decidim::AttributeObject::Model
-      include ActiveModel::Validations
+    include Decidim::AttributeObject::Model
+    include ActiveModel::Validations
 
-      attribute :title
-      attribute :body
+    attribute :title
+    attribute :body
 
-      validates :title, :body, etiquette: true
+    validates :title, :body, etiquette: true
 
-      def awesome_config
-        Decidim::DecidimAwesome::Config.new(Decidim::Organization.first)
-      end
+    def awesome_config
+      @awesome_config ||= Decidim::DecidimAwesome::Config.new(Decidim::Organization.first)
     end
   end
 
@@ -40,6 +38,9 @@ describe EtiquetteValidator do
   let!(:validate_body_max_caps_percent) { create(:awesome_config, organization:, var: :validate_body_max_caps_percent, value: body_max_caps_percent) }
   let!(:validate_body_max_marks_together) { create(:awesome_config, organization:, var: :validate_body_max_marks_together, value: body_max_marks_together) }
   let!(:validate_body_start_with_caps) { create(:awesome_config, organization:, var: :validate_body_start_with_caps, value: body_start_with_caps) }
+  let!(:constraint) { create(:config_constraint, awesome_config: config_helper, settings:) }
+  let(:config_helper) { validate_title_max_caps_percent }
+  let(:settings) { {} }
 
   it { is_expected.to be_valid }
 
@@ -53,6 +54,12 @@ describe EtiquetteValidator do
         let(:"#{attribute}_max_caps_percent") { 100 }
 
         it { is_expected.to be_valid }
+
+        context "and context is not valid" do
+          let(:settings) { { participatory_space_slug: "other-slug" } }
+
+          it { is_expected.not_to be_valid }
+        end
       end
     end
   end


### PR DESCRIPTION
- Fixes crash in changing locales if HashCash is activated. After this PR the approach is conservative: HashCash only applies to the "POST" action in the registration/session controllers.
 - Fixes #446 Additionally, this was affecting many other variables not respecting the context where they where defined for.