### PR TITLE
System access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Compatibility:
 
 Fixes:
   - Hide components and resources protected with an authorization from the last_activities feed, api and open data.
+  - Allow to log in directly into /system if the administrator is also a System administrator
 
 v0.13.2
 -------

--- a/README.md
+++ b/README.md
@@ -482,14 +482,6 @@ Depending on your Decidim version, choose the corresponding Awesome version to e
 | 0.6.x | 0.22.x, 0.23.x |
 | 0.5.x | 0.21.x, 0.22.x |
 
-> *Heads up!*
-> * version 0.11.0 is only compatible with Decidim v0.28 as a major redesign makes backward compatibility impractical.
-> * version 0.10.0 requires database migrations! Don't forget the migrations step when updating.
-> * version 0.8.0 removes CSS Themes for tenants. If you have been using them you will have to manually migrate them to custom styles.
-> * version 0.8.0 uses ActiveStorage, same as Decidim 0.25. 2 new rake task have been introduced to facilitate the migration: `bin/rails decidim_awesome:active_storage_migrations:check_migration_from_carrierwave` and
-`bin/rails decidim_awesome:active_storage_migrations:migrate_from_carrierwave`
-> * version 0.7.1 requires database migrations! Don't forget the migrations step when updating.
-
 ## Configuration
 
 Each tweak can be enabled or disabled by default. It also can be deactivated so

--- a/app/controllers/concerns/decidim/decidim_awesome/enforce_access_authorizations.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/enforce_access_authorizations.rb
@@ -16,8 +16,9 @@ module Decidim
         return if skip_enforcement_for_current_request?
 
         unless service.granted?
-          flash[:alert] = I18n.t("decidim.decidim_awesome.session.authorization_is_required",
-                                 authorizations: service.adapters.map(&:fullname).join(", "))
+          key = user_signed_in? ? "authorization_is_required" : "login_and_authorization_is_required"
+          flash[:alert] = I18n.t(key, scope: "decidim.decidim_awesome.session",
+                                      authorizations: service.adapters.map(&:fullname).join(", "))
           redirect_to decidim_decidim_awesome.required_authorizations_path(redirect_url: request.fullpath)
         end
       end

--- a/app/controllers/decidim/decidim_awesome/admin/checks_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/checks_controller.rb
@@ -9,11 +9,19 @@ module Decidim
       class ChecksController < DecidimAwesome::Admin::ApplicationController
         include NeedsAwesomeConfig
         include MaintenanceContext
+        include SystemCheckerHelpers
 
         helper ConfigConstraintsHelpers
         helper SystemCheckerHelpers
 
         helper_method :head, :admin_head, :head_addons, :admin_addons
+
+        def index; end
+
+        def system_login
+          sign_in(:admin, system_admin) unless admin_signed_in?
+          redirect_to decidim_system.root_path
+        end
 
         private
 

--- a/app/helpers/decidim/decidim_awesome/admin/system_checker_helpers.rb
+++ b/app/helpers/decidim/decidim_awesome/admin/system_checker_helpers.rb
@@ -24,15 +24,12 @@ module Decidim
           SystemChecker.valid?(spec, file)
         end
 
-        def images_migrated?
-          pending_image_migrations.zero?
+        def system_admin?
+          DecidimAwesome.enabled?(:link_admin_to_system_admins) && current_user && current_user.admin? && system_admin.present?
         end
 
-        def pending_image_migrations
-          @pending_image_migrations ||= begin
-            images = Decidim::DecidimAwesome::EditorImage.where(organization: current_organization)
-            images.count - images.joins(:file_attachment).count
-          end
+        def system_admin
+          @system_admin ||= Decidim::System::Admin.find_by(email: current_user&.email)
         end
       end
     end

--- a/app/views/decidim/decidim_awesome/admin/checks/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/checks/index.html.erb
@@ -10,18 +10,13 @@
   </p>
 </div>
 
+<% if system_admin? %>
 <div class="card-section">
-  <p><%= t(".images_migrated") %>
-  <% if images_migrated? %>
-    <%= check true %></p>
-  <% else %>
-    <%= check false %></p>
-    <div class="callout alert">
-      <p><%= t(".pending_image_migrations", total: pending_image_migrations).html_safe %></p>
-      <%= link_to t(".start_image_migrations"), migrate_images_path, method: :post, class: "button" %>
-    </div>
-  <% end %>
+  <p>
+    <%= link_to t(".link_admins"), decidim_admin_decidim_awesome.checks_path, method: :post, target: "_blank", class: "button button__primary button__xs", data: { "external-domain-link" => false } %>
+  </p>
 </div>
+<% end %>
 
 <div class="card-section">
   <ul class="vertical menu">

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -40,6 +40,8 @@ ignore_unused:
   - "decidim.decidim_awesome.admin_log.*"
   - "decidim.decidim_awesome.required_authorizations.index.verify_with_all_these_options"
   - "decidim.decidim_awesome.required_authorizations.index.verify_with_any_of_these_options"
+  - "decidim.decidim_awesome.session.login_and_authorization_is_required"
+  - "decidim.decidim_awesome.session.authorization_is_required"
   - "layouts.decidim.decidim_awesome.admin.maintenance.titles.*"
   - "decidim.proposals.*"
   - "decidim.meetings.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,8 +771,10 @@ en:
             one of these options before being able to access the platform:'
           verify_with_method: Verify with %{name}
       session:
-        authorization_is_required: In order to participate in this platform, you need
-          to authorize your account with a valid authorization (%{authorizations}).
+        authorization_is_required: In order to access this part of the platform, you
+          need to authorize your account with a valid authorization (%{authorizations}).
+        login_and_authorization_is_required: In order to access this part of the platform,
+          you need to log in and authorize your account.
       system:
         organizations:
           admin_allowed_authoritzations_help_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,13 +264,7 @@ en:
               JavaScript: Head does not contain the required <script> Javascript entries.
                 To solve it, you can manually add it to your custom admin/_header.html.erb
             head_tags: Awesome tags included in the application header
-            image_migrations_started: Images migration process has been started successfully
-            images_migrated: Images migrated to ActiveStorage
-            pending_image_migrations: |
-              Since version 0.25, Decidim uses a new technology to upload files.<br>
-              It looks that this installation needs to migrate <strong>%{total}</strong> of the old images to the new system.<br>
-              You can start the process now and it will be performed in the background.
-            start_image_migrations: "👉 Start the migration process now"
+            link_admins: Login into /system panel
         config:
           anonymous: Non-logged users
           caution: 'NOTE: This feature heavily modifies some default behaviors that

--- a/lib/decidim/decidim_awesome/admin_engine.rb
+++ b/lib/decidim/decidim_awesome/admin_engine.rb
@@ -31,6 +31,7 @@ module Decidim
         post :rename_scope_label, to: "config#rename_scope_label"
         scope :maintenance do
           get :checks, to: "checks#index"
+          post :checks, to: "checks#system_login"
           resources :private_data, only: [:index, :destroy]
           resources :hashcash, only: [:index, :show], as: "hashcashes" do
             get :ip_addresses, on: :collection

--- a/lib/decidim/decidim_awesome/awesome.rb
+++ b/lib/decidim/decidim_awesome/awesome.rb
@@ -223,6 +223,14 @@ module Decidim
       %w(account)
     end
 
+    # If true, admins can automatically login into the /system admin accounts without needing their password
+    # Note that a system admin MUST be a site admin too (emails must match).
+    # Otherwise, the login will be denied.
+    # Set to :disabled to completely remove this feature
+    config_accessor :link_admin_to_system_admins do
+      true
+    end
+
     # How old must be the private data to be considered expired and therefore presented to the admins for deletion
     config_accessor :private_data_expiration_time do
       3.months

--- a/spec/system/admin/admin_spec.rb
+++ b/spec/system/admin/admin_spec.rb
@@ -33,6 +33,46 @@ describe "Visit the admin page" do
     end
   end
 
+  context "when login into /system" do
+    let!(:system_admin) { create(:admin, email: admin.email) }
+
+    before do
+      click_link_or_button "System Compatibility"
+    end
+
+    context "when link_admin_to_system_admins is enabled" do
+      it "logs in the admin as system admin and redirects to /system" do
+        system_window = window_opened_by do
+          click_on "Login into /system panel"
+        end
+        within_window system_window do
+          expect(page).to have_current_path(decidim_system.root_path)
+        end
+        visit decidim_system.root_path
+        expect(page).to have_content("Dashboard")
+        expect(page).to have_link("New organization")
+      end
+
+      context "when admin is not a system admin" do
+        let!(:system_admin) { create(:admin) }
+
+        it "does not show the link to login into /system" do
+          expect(page).to have_no_link("Login into /system panel")
+        end
+      end
+    end
+
+    context "when link_admin_to_system_admins is disabled" do
+      let(:disabled_features) do
+        [:link_admin_to_system_admins]
+      end
+
+      it "does not show the link to login into /system" do
+        expect(page).to have_no_link("Login into /system panel")
+      end
+    end
+  end
+
   context "when visiting system compatibility" do
     before do
       click_link_or_button "System Compatibility"


### PR DESCRIPTION
- [x] Allows admins with a user in /system to log in directly from the "maintenance" page
- [x] Separates the text for the callout for logged users/non logged users for the verification restrited pages
- [x] Removes some remaining text related to migration to activestorage