### PR TITLE
fix: add null check for component in awesome_map API fetcher

### DIFF
--- a/app/packs/src/decidim/decidim_awesome/awesome_map/api/fetcher.js
+++ b/app/packs/src/decidim/decidim_awesome/awesome_map/api/fetcher.js
@@ -29,6 +29,10 @@ export default class Fetcher {
     const api = new ApiFetcher(this.query, variables);
     api.fetchAll((result) => {
       if (result) {
+        if (!result.component) {
+          this.onFinished();
+          return;
+        }
         const collection = result.component[this.collection];
         collection.edges = collection.edges.filter((edge) => edge.node !== null);
         // console.log("collection", collection)


### PR DESCRIPTION
In a Decidim environment I was testing, I encountered a case where the `result` from `api.fetchAll()` in the `Fetcher.fetch()` function (decidim/decidim_awesome/awesome_map/api/fetcher.js) returned `{"component": null}`.

In this case, accessing `result.component[this.collection]` in fetcher.js throws an error.

This PR adds a null check for `result.component` and calls `onFinished()` before returning early to prevent the error.
