### PR TITLE
fix: remove `RAILS_ENV` from mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,0 @@
-[env]
-DATABASE_USERNAME="decidim_app"
-DATABASE_PASSWORD="decidim123456789"
-CENSUS_URL="http://webapps01.getxo.org/WSConsultaPadron/WSConsultaPadron.asmx"
-
-[tools]
-node = "22"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,4 @@
 [env]
-RAILS_ENV="development"
 DATABASE_USERNAME="decidim_app"
 DATABASE_PASSWORD="decidim123456789"
 CENSUS_URL="http://webapps01.getxo.org/WSConsultaPadron/WSConsultaPadron.asmx"


### PR DESCRIPTION
When using mise for local development environment, the `RAILS_ENV` environment variable was hardcoded to `"development"` in mise.toml.
This prevented running tests properly because RSpec could not set `RAILS_ENV=test`; the mise configuration always overrode it with `"development"`.

This PR removes `RAILS_ENV` from mise.toml to allow test frameworks to set the appropriate environment.
Developers can still set `RAILS_ENV` manually when needed.