### PR TITLE
Fix process group form override

### DIFF
--- a/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
@@ -1,4 +1,5 @@
 <!-- insert_bottom "div#panel-visibility" -->
-<% if controller.action_name == "edit" %>
-  <%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
-<% end %>
+<% participatory_space = params[:id].nil? ? nil : participatory_process_group %>
+
+<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_space %>
+

--- a/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
@@ -1,3 +1,4 @@
 <!-- insert_bottom "div#panel-visibility" -->
-
-<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
+<% if controller.action_name == "edit" %>
+  <%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
+<% end %>


### PR DESCRIPTION
🎩 Description
This PR fixes an error linked to a deface override of process group form, so that the process group new view in admin is accessible.

Testing
1. As an admin, go to processes > process groups
2. Click on 'New process group'
3. See that you can access the new view without error

📌 Related Issues
Fixes https://github.com/decidim-ice/decidim-module-decidim_awesome/issues/496

📷 Screenshots
<img width="1062" height="656" alt="Capture d’écran 2025-12-18 à 10 34 24" src="https://github.com/user-attachments/assets/3d7e02d8-d8d1-4b24-a332-1d7bd8e57f08" />

