### PR TITLE
Remove migrate images checker in 0.29

### DIFF
--- a/app/helpers/decidim/decidim_awesome/admin/system_checker_helpers.rb
+++ b/app/helpers/decidim/decidim_awesome/admin/system_checker_helpers.rb
@@ -23,17 +23,6 @@ module Decidim
         def valid?(spec, file)
           SystemChecker.valid?(spec, file)
         end
-
-        def images_migrated?
-          pending_image_migrations.zero?
-        end
-
-        def pending_image_migrations
-          @pending_image_migrations ||= begin
-            images = Decidim::DecidimAwesome::EditorImage.where(organization: current_organization)
-            images.count - images.joins(:file_attachment).count
-          end
-        end
       end
     end
   end

--- a/app/views/decidim/decidim_awesome/admin/checks/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/checks/index.html.erb
@@ -11,19 +11,6 @@
 </div>
 
 <div class="card-section">
-  <p><%= t(".images_migrated") %>
-  <% if images_migrated? %>
-    <%= check true %></p>
-  <% else %>
-    <%= check false %></p>
-    <div class="callout alert">
-      <p><%= t(".pending_image_migrations", total: pending_image_migrations).html_safe %></p>
-      <%= link_to t(".start_image_migrations"), migrate_images_path, method: :post, class: "button" %>
-    </div>
-  <% end %>
-</div>
-
-<div class="card-section">
   <ul class="vertical menu">
     <% overrides.each do |group, props| %>
       <li>

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -224,13 +224,6 @@ es:
               CSS: El encabezado no contiene las entradas requeridas <link> a la hoja de estilo. Para resolverlo, se pueden añadir manualmente al fichero personalizado _head.html.erb
               JavaScript: El encabezado no contiene las entradas requeridas de Javascript <script>. Para resolverlo, se pueden añadir manualmente al fichero personalizado admin/_header.html.erb
             head_tags: Etiquetas Awesome incluidas en el encabezado de la aplicación
-            image_migrations_started: El proceso de migración de imágenes ha iniciado correctamente
-            images_migrated: Imágenes migradas a ActiveStorage
-            pending_image_migrations: |
-              Desde la versión 0.25, Decidim utiliza una nueva tecnología para subir archivos.<br>
-              Parece que esta instalación necesita migrar <strong>%{total}</strong> imágenes antiguas al nuevo sistema.<br>
-              Puedes iniciar el proceso ahora y se realizará en segundo plano.
-            start_image_migrations: "\U0001F449 Iniciar el proceso de migración ahora"
         config:
           anonymous: Usuarios no identificados
           caution: 'NOTA: Esta función modifica en gran medida algunos comportamientos por defecto que pueden llevar a resultados inesperados. ¡Utilícelo con precaución!'


### PR DESCRIPTION
In version 0.29, the option to migrate missing images appears, but clicking it fails. This option seems to be legacy because the job it was running and the action in the controller no longer exist.

<img width="1641" height="900" alt="image" src="https://github.com/user-attachments/assets/466e9009-bbc5-4e73-ac9c-bdcffcf1d487" />

This PR removes anything related to image migration.
