### PR TITLE
Fix Awesome Processes content block filtering and reordering

### DIFF
--- a/app/cells/decidim/decidim_awesome/content_blocks/awesome_processes_form/show.erb
+++ b/app/cells/decidim/decidim_awesome/content_blocks/awesome_processes_form/show.erb
@@ -21,7 +21,8 @@
     </div>
   </div>
 
-  <div class="row column">
+  <div class="row column" data-awesome-processes-group-filter
+       <%= "hidden" if settings_fields.object.process_type == "processes" %>>
     <%= settings_fields.select :process_group_id,
                                process_group_options,
                                label: t("process_group", scope: i18n_scope) %>
@@ -40,6 +41,8 @@
   </div>
 
   <div class="row column" data-awesome-processes-manual
+       data-move-up-title="<%= t("move_up", scope: i18n_scope) %>"
+       data-move-down-title="<%= t("move_down", scope: i18n_scope) %>"
        <%= "hidden" unless settings_fields.object.selection_criteria == "manual" %>>
     <%= settings_fields.select :selected_ids,
                                processes_for_select,

--- a/app/cells/decidim/decidim_awesome/content_blocks/awesome_processes_form_cell.rb
+++ b/app/cells/decidim/decidim_awesome/content_blocks/awesome_processes_form_cell.rb
@@ -24,11 +24,8 @@ module Decidim
 
         def process_group_options
           groups = Decidim::ParticipatoryProcessGroup.where(organization: current_organization)
-          opts = [[t("any_group", scope: i18n_scope), 0]]
-          groups.find_each do |group|
-            opts << [translated_attribute(group.title), group.id]
-          end
-          opts
+          [[t("any_group", scope: i18n_scope), 0]] +
+            groups.map { |group| [translated_attribute(group.title), group.id] }
         end
 
         def process_status_options
@@ -48,21 +45,48 @@ module Decidim
         end
 
         def processes_for_select
-          processes = published_processes.map do |process|
-            ["##{process.id} - #{translated_attribute(process.title)}", "process_#{process.id}"]
-          end
-
-          groups = Decidim::ParticipatoryProcessGroup.where(organization: current_organization).map do |group|
-            ["[#{t("group_label", scope: i18n_scope)}] #{translated_attribute(group.title)}", "group_#{group.id}"]
-          end
-
-          processes + groups
+          reorder_by_saved_selection(build_process_options)
         end
 
         private
 
+        def build_process_options
+          published_processes.map do |process|
+            label = translated_attribute(process.title)
+            attrs = {
+              "data-group-id" => process.decidim_participatory_process_group_id.to_i,
+              "data-status" => process_status_for(process)
+            }
+            [label, process.id.to_s, attrs]
+          end
+        end
+
+        # Puts selected items first in saved order so TomSelect initializes with correct ordering
+        def reorder_by_saved_selection(all_options)
+          saved_ids = Array(content_block&.settings&.selected_ids).compact_blank
+          return all_options if saved_ids.empty?
+
+          options_by_value = all_options.index_by { |_, val| val }
+          saved_set = saved_ids.to_set
+          selected = saved_ids.filter_map { |id| options_by_value[id] }
+          unselected = all_options.reject { |_, val| saved_set.include?(val) }
+          selected + unselected
+        end
+
+        def process_status_for(process)
+          if process.upcoming?
+            "upcoming"
+          elsif process.past?
+            "past"
+          else
+            "active"
+          end
+        end
+
         def published_processes
-          Decidim::ParticipatoryProcess.where(organization: current_organization).published
+          Decidim::ParticipatoryProcesses::OrganizationPublishedParticipatoryProcesses
+            .new(current_organization, current_user)
+            .query
         end
       end
     end

--- a/app/packs/src/decidim/decidim_awesome/admin/awesome_processes_form.js
+++ b/app/packs/src/decidim/decidim_awesome/admin/awesome_processes_form.js
@@ -1,4 +1,7 @@
 import TomSelect from "tom-select/dist/cjs/tom-select.popular";
+import reorderPlugin from "src/decidim/decidim_awesome/admin/tom_select_reorder";
+
+TomSelect.define("reorder_buttons", reorderPlugin);
 
 document.addEventListener("turbo:load", () => {
   const criteriaContainer = document.querySelector("[data-awesome-processes-criteria]");
@@ -13,13 +16,109 @@ document.addEventListener("turbo:load", () => {
   }
 
   const multiSelect = manualContainer.querySelector("select.awesome-processes-tom-select");
-  if (multiSelect) {
-    // eslint-disable-next-line no-new
-    new TomSelect(multiSelect, {
-      plugins: ["remove_button"],
-      create: false
-    });
+  if (!multiSelect) {
+    return;
   }
+
+  // Read data attributes from <option> elements before TomSelect replaces them
+  const optionMeta = {};
+  multiSelect.querySelectorAll("option").forEach((opt) => {
+    if (opt.value) {
+      optionMeta[opt.value] = {
+        groupId: parseInt(opt.dataset.groupId || "0", 10),
+        status: opt.dataset.status || ""
+      };
+    }
+  });
+
+  /* eslint-disable camelcase */
+  const plugins = {
+    remove_button: {},
+    reorder_buttons: {
+      upTitle: manualContainer.dataset.moveUpTitle || "↑",
+      downTitle: manualContainer.dataset.moveDownTitle || "↓"
+    }
+  };
+  /* eslint-enable camelcase */
+  const tomSelect = new TomSelect(multiSelect, { plugins, create: false });
+
+  const allOptions = Object.values(tomSelect.options).map((opt) => ({ ...opt }));
+
+  const typeSelect = document.querySelector("[data-awesome-processes-type] select");
+  const groupSelect = document.querySelector("[name*='process_group_id']");
+  const statusSelect = document.querySelector("[name*='process_status']");
+
+  const filterOptions = () => {
+    const processType = typeSelect
+      ? typeSelect.value
+      : "all";
+    const groupId = groupSelect
+      ? parseInt(groupSelect.value, 10)
+      : 0;
+    const status = statusSelect
+      ? statusSelect.value
+      : "active";
+    const selectedValues = tomSelect.getValue();
+
+    tomSelect.clearOptions();
+
+    allOptions.forEach((opt) => {
+      const meta = optionMeta[opt.value];
+      if (!meta) {
+        tomSelect.addOption(opt);
+        return;
+      }
+
+      // Type filter: "processes" = without group, "groups" = with group, "all" = both
+      if (processType === "processes" && meta.groupId > 0) {
+        return;
+      }
+      if (processType === "groups" && meta.groupId === 0) {
+        return;
+      }
+
+      // Group restriction: for "all" type, ungrouped processes always pass
+      if (groupId > 0 && meta.groupId !== groupId && !(processType === "all" && meta.groupId === 0)) {
+        return;
+      }
+
+      // Status filter
+      if (status !== "all" && meta.status !== status) {
+        return;
+      }
+
+      tomSelect.addOption(opt);
+    });
+
+    // Preserve already-selected items even if they no longer match filters
+    if (Array.isArray(selectedValues)) {
+      selectedValues.forEach((val) => {
+        if (!tomSelect.options[val]) {
+          const original = allOptions.find((op) => op.value === val);
+          if (original) {
+            tomSelect.addOption(original);
+          }
+        }
+        if (tomSelect.options[val]) {
+          tomSelect.addItem(val, true);
+        }
+      });
+    }
+
+    tomSelect.refreshOptions(false);
+  };
+
+  if (typeSelect) {
+    typeSelect.addEventListener("change", filterOptions);
+  }
+  if (groupSelect) {
+    groupSelect.addEventListener("change", filterOptions);
+  }
+  if (statusSelect) {
+    statusSelect.addEventListener("change", filterOptions);
+  }
+
+  filterOptions();
 
   const toggleCriteriaVisibility = () => {
     manualContainer.hidden = criteriaSelect.value !== "manual";
@@ -27,16 +126,23 @@ document.addEventListener("turbo:load", () => {
 
   criteriaSelect.addEventListener("change", toggleCriteriaVisibility);
 
-  const typeContainer = document.querySelector("[data-awesome-processes-type]");
+  // Toggle group filter visibility: hidden when type = "processes" (ungrouped only)
+  const groupFilterContainer = document.querySelector("[data-awesome-processes-group-filter]");
   const mixedHint = document.querySelector("[data-awesome-processes-mixed-hint]");
-  if (typeContainer && mixedHint) {
-    const typeSelect = typeContainer.querySelector("select");
-    if (typeSelect) {
-      const toggleMixedHint = () => {
-        mixedHint.hidden = typeSelect.value !== "all";
-      };
 
-      typeSelect.addEventListener("change", toggleMixedHint);
-    }
+  if (typeSelect) {
+    const toggleTypeDependent = () => {
+      if (groupFilterContainer) {
+        groupFilterContainer.hidden = typeSelect.value === "processes";
+        if (typeSelect.value === "processes" && groupSelect) {
+          groupSelect.value = "0";
+        }
+      }
+      if (mixedHint) {
+        mixedHint.hidden = typeSelect.value !== "all";
+      }
+    };
+
+    typeSelect.addEventListener("change", toggleTypeDependent);
   }
 });

--- a/app/packs/src/decidim/decidim_awesome/admin/tom_select_reorder.js
+++ b/app/packs/src/decidim/decidim_awesome/admin/tom_select_reorder.js
@@ -1,0 +1,88 @@
+// TomSelect plugin: adds move up/down buttons to selected items for reordering.
+// Follows the same pattern as TomSelect's built-in "remove_button" plugin.
+// Move logic mirrors Decidim's DynamicFieldsComponent (_moveUpField/_moveDownField).
+
+/* eslint-disable require-jsdoc, no-invalid-this, consistent-this */
+export default function (userOptions) {
+  const self = this;
+  if (self.settings.mode !== "multi") {
+    return;
+  }
+
+  const options = Object.assign({ upTitle: "↑", downTitle: "↓" }, userOptions);
+
+  const syncOrder = () => {
+    const values = [];
+    self.control.querySelectorAll("[data-value]").forEach((el) => {
+      if (el.dataset.value) {
+        values.push(el.dataset.value);
+      }
+    });
+    self.setValue(values, true);
+  };
+
+  // Bind delegated listeners after TomSelect creates the control element
+  self.on("initialize", () => {
+    self.control.addEventListener("click", (ev) => {
+      const btn = ev.target.closest(".reorder-btn");
+      if (!btn) {
+        return;
+      }
+      ev.preventDefault();
+      ev.stopPropagation();
+
+      const item = btn.closest("[data-value]");
+      if (!item) {
+        return;
+      }
+
+      if (btn.classList.contains("reorder-up") && item.previousElementSibling?.dataset.value) {
+        item.parentNode.insertBefore(item, item.previousElementSibling);
+        syncOrder();
+      } else if (btn.classList.contains("reorder-down") && item.nextElementSibling?.dataset.value) {
+        item.parentNode.insertBefore(item.nextElementSibling, item);
+        syncOrder();
+      }
+    });
+
+    self.control.addEventListener("mousedown", (ev) => {
+      if (ev.target.closest(".reorder-btn")) {
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    }, true);
+  });
+
+  // Append reorder buttons to each rendered item
+  self.hook("after", "setupTemplates", () => {
+    const origRenderItem = self.settings.render.item;
+
+    self.settings.render.item = (data, escape) => {
+      const item = Reflect.apply(origRenderItem, self, [data, escape]);
+      const el = (typeof item === "string")
+        ? new DOMParser().parseFromString(item, "text/html").body.firstChild
+        : item;
+
+      const btnUp = document.createElement("button");
+      btnUp.type = "button";
+      btnUp.className = "reorder-btn reorder-up";
+      btnUp.textContent = "↑";
+      btnUp.title = options.upTitle;
+      btnUp.setAttribute("aria-label", options.upTitle);
+      btnUp.tabIndex = 0;
+
+      const btnDown = document.createElement("button");
+      btnDown.type = "button";
+      btnDown.className = "reorder-btn reorder-down";
+      btnDown.textContent = "↓";
+      btnDown.title = options.downTitle;
+      btnDown.setAttribute("aria-label", options.downTitle);
+      btnDown.tabIndex = 0;
+
+      el.insertBefore(btnDown, el.firstChild);
+      el.insertBefore(btnUp, el.firstChild);
+
+      return el;
+    };
+  });
+}

--- a/app/packs/stylesheets/decidim/decidim_awesome/admin/_tom_select_reorder.scss
+++ b/app/packs/stylesheets/decidim/decidim_awesome/admin/_tom_select_reorder.scss
@@ -1,6 +1,5 @@
 [data-awesome-processes-manual] .ts-control {
-  flex-direction: column !important;
-  flex-wrap: nowrap !important;
+  flex-flow: column nowrap !important;
   gap: 0.25rem;
 
   > .item {

--- a/app/packs/stylesheets/decidim/decidim_awesome/admin/_tom_select_reorder.scss
+++ b/app/packs/stylesheets/decidim/decidim_awesome/admin/_tom_select_reorder.scss
@@ -1,0 +1,29 @@
+[data-awesome-processes-manual] .ts-control {
+  flex-direction: column !important;
+  flex-wrap: nowrap !important;
+  gap: 0.25rem;
+
+  > .item {
+    display: flex !important;
+    align-items: center;
+    gap: 0.25rem;
+    width: fit-content;
+    margin: 0 !important;
+  }
+
+  .reorder-btn {
+    flex-shrink: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0.1rem 0.25rem;
+    font-size: 0.75rem;
+    line-height: 1;
+    color: inherit;
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/app/packs/stylesheets/decidim/decidim_awesome/awesome_admin_global.scss
+++ b/app/packs/stylesheets/decidim/decidim_awesome/awesome_admin_global.scss
@@ -2,6 +2,7 @@
 @import "stylesheets/decidim/decidim_awesome/admin/intergram_fixes";
 @import "stylesheets/decidim/decidim_awesome/forms/custom_fields";
 @import "stylesheets/decidim/decidim_awesome/admin/verifications";
+@import "stylesheets/decidim/decidim_awesome/admin/tom_select_reorder";
 
 .component__show {
   &_private_data {

--- a/app/queries/decidim/decidim_awesome/awesome_processes_query.rb
+++ b/app/queries/decidim/decidim_awesome/awesome_processes_query.rb
@@ -2,8 +2,13 @@
 
 module Decidim
   module DecidimAwesome
-    # Query class responsible for fetching participatory processes and/or groups
-    # based on content block settings. Supports automatic (active) and manual selection.
+    # Query class responsible for fetching participatory processes
+    # based on content block settings.
+    #
+    # Process types:
+    #   - "processes": only processes WITHOUT a group
+    #   - "groups": only processes WITH a group (optionally restricted to a specific group)
+    #   - "all": all processes regardless of group membership
     class AwesomeProcessesQuery
       def initialize(organization, current_user, settings)
         @organization = organization
@@ -29,35 +34,26 @@ module Decidim
       end
 
       def automatic_selection
-        return fetch_processes.first(max_results) if settings.process_type == "processes"
-        return fetch_groups.first(max_results) if settings.process_type == "groups"
-
-        interleave(fetch_processes, fetch_groups).first(max_results)
+        fetch_processes
       end
 
       def manual_selection
-        process_ids = []
-        group_ids = []
+        ids = selected_process_ids
+        return [] if ids.empty?
 
-        selected_ids.each do |id_str|
-          type, id = id_str.split("_", 2)
-          case type
-          when "process" then process_ids << id.to_i
-          when "group" then group_ids << id.to_i
-          end
-        end
+        scope = published_processes.where(id: ids).includes(:organization, :hero_image_attachment)
+        scope = apply_type_filter(scope)
+        scope = apply_group_filter(scope)
 
-        items_by_key = {}
-        published_processes.where(id: process_ids).each { |p| items_by_key["process_#{p.id}"] = p } if process_ids.any?
-        organization_groups.where(id: group_ids).each { |g| items_by_key["group_#{g.id}"] = g } if group_ids.any?
-
-        selected_ids.filter_map { |id_str| items_by_key[id_str] }.first(max_results)
+        items_by_id = scope.index_by(&:id)
+        ids.filter_map { |id| items_by_id[id] }.first(max_results)
       end
 
       def fetch_processes
         scope = published_processes
         scope = apply_status_filter(scope)
-        scope = scope.where(decidim_participatory_process_group_id: settings.process_group_id) if group_filter_active?
+        scope = apply_type_filter(scope)
+        scope = apply_group_filter(scope)
         scope.reorder(weight: :asc, id: :asc)
              .includes(:organization, :hero_image_attachment)
              .limit(max_results)
@@ -73,12 +69,28 @@ module Decidim
         end
       end
 
-      def fetch_groups
-        scope = organization_groups
-        scope = scope.where(id: settings.process_group_id) if group_filter_active?
-        scope.order(promoted: :desc, id: :asc)
-             .limit(max_results)
-             .to_a
+      def apply_type_filter(scope)
+        case settings.process_type
+        when "processes"
+          scope.where(decidim_participatory_process_group_id: nil)
+        when "groups"
+          scope.where.not(decidim_participatory_process_group_id: nil)
+        else
+          scope
+        end
+      end
+
+      # When type = "all", restrict applies only to grouped processes — ungrouped always pass
+      # When type = "processes", group filter is irrelevant (ungrouped processes have no group)
+      def apply_group_filter(scope)
+        return scope unless group_filter_active?
+        return scope if settings.process_type == "processes"
+
+        if settings.process_type == "all"
+          scope.where(decidim_participatory_process_group_id: [settings.process_group_id, nil])
+        else
+          scope.where(decidim_participatory_process_group_id: settings.process_group_id)
+        end
       end
 
       def published_processes
@@ -87,32 +99,16 @@ module Decidim
           .query
       end
 
-      def organization_groups
-        Decidim::ParticipatoryProcessGroup.where(organization: organization)
-      end
-
       def group_filter_active?
         settings.process_group_id.to_i.positive?
       end
 
-      def selected_ids
-        settings.selected_ids.compact_blank
+      def selected_process_ids
+        settings.selected_ids.compact_blank.map(&:to_i).reject(&:zero?)
       end
 
       def max_results
-        [settings.max_results.to_i, 0].max
-      end
-
-      # Alternates items from two arrays: [a1, b1, a2, b2, ...].
-      # When one array is exhausted, appends remaining items from the other.
-      def interleave(arr_a, arr_b)
-        result = []
-        max_len = [arr_a.size, arr_b.size].max
-        max_len.times do |i|
-          result << arr_a[i] if i < arr_a.size
-          result << arr_b[i] if i < arr_b.size
-        end
-        result
+        [settings.max_results.to_i, 1].max
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,6 +748,8 @@ en:
           any_group: Any group
           group_label: Group
           max_results: Maximum amount of elements to show
+          move_down: Move down
+          move_up: Move up
           name: Awesome Processes
           process_group: Restrict to process group
           process_status: Process status filter
@@ -757,11 +759,9 @@ en:
             past: Only past processes
             upcoming: Only future processes
           process_type: Type of processes
-          process_type_mixed_hint: In mixed mode, processes and groups are interleaved
-            up to the maximum amount. Processes are sorted by weight (ascending).
-            If one type runs out, the remaining slots are filled with the other.
+          process_type_mixed_hint: Shows all processes up to the maximum amount.
           process_types:
-            all: All processes and groups mixed
+            all: All processes
             groups: Only process groups
             processes: Only processes
           processes: Processes

--- a/spec/cells/content_blocks/awesome_processes_cell_spec.rb
+++ b/spec/cells/content_blocks/awesome_processes_cell_spec.rb
@@ -10,9 +10,10 @@ module Decidim::DecidimAwesome
     let(:content_block) { create(:content_block, organization:, manifest_name: :awesome_processes, scope_name: :homepage, settings:) }
     let(:settings) { {} }
 
-    let!(:active_process) { create(:participatory_process, :active, :published, organization:) }
-    let!(:past_process) { create(:participatory_process, :past, :published, organization:) }
     let!(:process_group) { create(:participatory_process_group, organization:) }
+    let!(:active_process) { create(:participatory_process, :active, :published, organization:) }
+    let!(:grouped_process) { create(:participatory_process, :active, :published, organization:, participatory_process_group: process_group) }
+    let!(:past_process) { create(:participatory_process, :past, :published, organization:) }
 
     controller Decidim::PagesController
 
@@ -23,6 +24,7 @@ module Decidim::DecidimAwesome
     it "renders active processes" do
       expect(subject).to have_css(".card__grid-home")
       expect(subject).to have_content(translated(active_process.title))
+      expect(subject).to have_content(translated(grouped_process.title))
     end
 
     it "does not show past processes with default settings" do
@@ -34,9 +36,7 @@ module Decidim::DecidimAwesome
     end
 
     context "when a custom title is set" do
-      let(:settings) do
-        { "title" => { "en" => "Featured Projects" } }
-      end
+      let(:settings) { { "title" => { "en" => "Featured Projects" } } }
 
       it "shows the custom title" do
         expect(subject).to have_css("h2", text: "Featured Projects")
@@ -46,23 +46,34 @@ module Decidim::DecidimAwesome
     context "when process_type is 'processes'" do
       let(:settings) { { process_type: "processes" } }
 
-      it "shows only processes" do
+      it "shows only processes without a group" do
         expect(subject).to have_content(translated(active_process.title))
-        expect(subject).to have_no_content(translated(process_group.title))
+        expect(subject).to have_no_content(translated(grouped_process.title))
       end
     end
 
     context "when process_type is 'groups'" do
       let(:settings) { { process_type: "groups" } }
 
-      it "shows only process groups" do
-        expect(subject).to have_content(translated(process_group.title))
+      it "shows only processes with a group" do
+        expect(subject).to have_content(translated(grouped_process.title))
         expect(subject).to have_no_content(translated(active_process.title))
+      end
+
+      context "when restricted to a specific group" do
+        let!(:other_group) { create(:participatory_process_group, organization:) }
+        let!(:other_grouped) { create(:participatory_process, :active, :published, organization:, participatory_process_group: other_group) }
+        let(:settings) { { process_type: "groups", process_group_id: process_group.id } }
+
+        it "shows only processes from that group" do
+          expect(subject).to have_content(translated(grouped_process.title))
+          expect(subject).to have_no_content(translated(other_grouped.title))
+        end
       end
     end
 
     context "when process_status is 'all'" do
-      let(:settings) { { process_type: "processes", process_status: "all" } }
+      let(:settings) { { process_status: "all" } }
 
       it "shows both active and past processes" do
         expect(subject).to have_content(translated(active_process.title))
@@ -71,7 +82,7 @@ module Decidim::DecidimAwesome
     end
 
     context "when process_status is 'past'" do
-      let(:settings) { { process_type: "processes", process_status: "past" } }
+      let(:settings) { { process_status: "past" } }
 
       it "shows only past processes" do
         expect(subject).to have_content(translated(past_process.title))
@@ -82,21 +93,26 @@ module Decidim::DecidimAwesome
     context "when max_results limits output" do
       let(:settings) { { max_results: 1 } }
 
-      let!(:another_active_process) { create(:participatory_process, :active, :published, organization:) }
-
       it "limits the number of displayed items" do
         expect(subject.all(".card__grid-home > *").count).to be <= 1
       end
     end
 
-    context "when filtering by process group" do
-      let!(:grouped_process) { create(:participatory_process, :active, :published, organization:, participatory_process_group: process_group) }
-      let!(:ungrouped_process) { create(:participatory_process, :active, :published, organization:) }
-      let(:settings) { { process_type: "processes", process_group_id: process_group.id } }
+    context "when filtering by process group (type: all)" do
+      let(:settings) { { process_group_id: process_group.id } }
+
+      it "shows grouped processes from that group and ungrouped processes" do
+        expect(subject).to have_content(translated(grouped_process.title))
+        expect(subject).to have_content(translated(active_process.title))
+      end
+    end
+
+    context "when filtering by process group (type: groups)" do
+      let(:settings) { { process_type: "groups", process_group_id: process_group.id } }
 
       it "shows only processes from the specified group" do
         expect(subject).to have_content(translated(grouped_process.title))
-        expect(subject).to have_no_content(translated(ungrouped_process.title))
+        expect(subject).to have_no_content(translated(active_process.title))
       end
     end
 
@@ -104,26 +120,13 @@ module Decidim::DecidimAwesome
       let(:settings) do
         {
           selection_criteria: "manual",
-          selected_ids: ["process_#{active_process.id}", "process_#{past_process.id}"]
+          selected_ids: [active_process.id.to_s, past_process.id.to_s]
         }
       end
 
       it "shows the manually selected processes" do
         expect(subject).to have_content(translated(active_process.title))
         expect(subject).to have_content(translated(past_process.title))
-      end
-    end
-
-    context "when manual selection includes groups" do
-      let(:settings) do
-        {
-          selection_criteria: "manual",
-          selected_ids: ["group_#{process_group.id}"]
-        }
-      end
-
-      it "shows the selected groups" do
-        expect(subject).to have_content(translated(process_group.title))
       end
     end
 

--- a/spec/cells/content_blocks/awesome_processes_form_cell_spec.rb
+++ b/spec/cells/content_blocks/awesome_processes_form_cell_spec.rb
@@ -47,7 +47,7 @@ module Decidim::DecidimAwesome
 
       it "has translated labels" do
         labels = cell_instance.process_type_options.map(&:first)
-        expect(labels).to include("All processes and groups mixed")
+        expect(labels).to include("All processes")
         expect(labels).to include("Only processes")
         expect(labels).to include("Only process groups")
       end
@@ -84,14 +84,6 @@ module Decidim::DecidimAwesome
         values = cell_instance.process_status_options.map(&:last)
         expect(values).to eq(%w(active all upcoming past))
       end
-
-      it "has translated labels" do
-        labels = cell_instance.process_status_options.map(&:first)
-        expect(labels).to include("Only active processes")
-        expect(labels).to include("All processes")
-        expect(labels).to include("Only future processes")
-        expect(labels).to include("Only past processes")
-      end
     end
 
     describe "#selection_criteria_options" do
@@ -100,51 +92,63 @@ module Decidim::DecidimAwesome
         expect(options.size).to eq(2)
       end
 
-      it "includes active and manual values" do
+      it "includes automatic and manual values" do
         values = cell_instance.selection_criteria_options.map(&:last)
         expect(values).to eq(%w(automatic manual))
-      end
-
-      it "has translated labels" do
-        labels = cell_instance.selection_criteria_options.map(&:first)
-        expect(labels).to include("Automatic")
-        expect(labels).to include("Manual")
       end
     end
 
     describe "#processes_for_select" do
-      it "returns published processes with correct format" do
+      it "returns only processes (no group cards)" do
         options = cell_instance.processes_for_select
-        process_options = options.select { |_, v| v.start_with?("process_") }
-        expect(process_options).not_to be_empty
-        label, value = process_options.first
-        expect(label).to start_with("##{published_process.id} - ")
-        expect(value).to eq("process_#{published_process.id}")
+        values = options.map { |_, val| val }
+        expect(values).to include(published_process.id.to_s)
+        expect(values).to all(match(/\A\d+\z/))
       end
 
-      it "returns groups with [Group] prefix" do
+      it "includes data-group-id and data-status attributes" do
         options = cell_instance.processes_for_select
-        group_options = options.select { |_, v| v.start_with?("group_") }
-        expect(group_options).not_to be_empty
-        label, value = group_options.first
-        expect(label).to start_with("[Group]")
-        expect(value).to eq("group_#{process_group.id}")
+        _, _, attrs = options.first
+        expect(attrs).to have_key("data-group-id")
+        expect(attrs).to have_key("data-status")
+      end
+
+      it "sets data-status based on process dates" do
+        active = create(:participatory_process, :active, :published, organization:)
+        past = create(:participatory_process, :past, :published, organization:)
+        upcoming = create(:participatory_process, :upcoming, :published, organization:)
+        options = cell_instance.processes_for_select
+
+        _, _, active_attrs = options.find { |_, val| val == active.id.to_s }
+        _, _, past_attrs = options.find { |_, val| val == past.id.to_s }
+        _, _, upcoming_attrs = options.find { |_, val| val == upcoming.id.to_s }
+        expect(active_attrs["data-status"]).to eq("active")
+        expect(past_attrs["data-status"]).to eq("past")
+        expect(upcoming_attrs["data-status"]).to eq("upcoming")
       end
 
       it "does not include unpublished processes" do
-        options = cell_instance.processes_for_select
-        values = options.map(&:last)
-        expect(values).not_to include("process_#{unpublished_process.id}")
+        values = cell_instance.processes_for_select.map { |_, val| val }
+        expect(values).not_to include(unpublished_process.id.to_s)
       end
 
-      it "does not include other organization's data" do
+      it "does not include other organization's processes" do
         other_org = create(:organization)
         other_process = create(:participatory_process, :published, organization: other_org)
-        other_group = create(:participatory_process_group, organization: other_org)
-        options = cell_instance.processes_for_select
-        values = options.map(&:last)
-        expect(values).not_to include("process_#{other_process.id}")
-        expect(values).not_to include("group_#{other_group.id}")
+        values = cell_instance.processes_for_select.map { |_, val| val }
+        expect(values).not_to include(other_process.id.to_s)
+      end
+
+      context "when there are saved selections" do
+        let!(:second_process) { create(:participatory_process, :published, organization:) }
+        let(:settings) { { selected_ids: [second_process.id.to_s, published_process.id.to_s] } }
+
+        it "puts selected items first in saved order" do
+          options = cell_instance.processes_for_select
+          values = options.map { |_, val| val }
+          expect(values.index(second_process.id.to_s)).to eq(0)
+          expect(values.index(published_process.id.to_s)).to eq(1)
+        end
       end
     end
 

--- a/spec/queries/decidim/decidim_awesome/awesome_processes_query_spec.rb
+++ b/spec/queries/decidim/decidim_awesome/awesome_processes_query_spec.rb
@@ -20,17 +20,18 @@ module Decidim
         }
       end
 
+      let!(:process_group) { create(:participatory_process_group, organization:) }
       let!(:active_process) { create(:participatory_process, :active, :published, organization:) }
+      let!(:grouped_process) { create(:participatory_process, :active, :published, organization:, participatory_process_group: process_group) }
       let!(:past_process) { create(:participatory_process, :past, :published, organization:) }
       let!(:unpublished_process) { create(:participatory_process, :active, :unpublished, organization:) }
-      let!(:process_group) { create(:participatory_process_group, organization:) }
 
       describe "#results with automatic selection" do
         context "with default settings (process_type: 'all')" do
-          it "returns active processes and groups" do
+          it "returns active processes from all types" do
             results = subject.results
             expect(results).to include(active_process)
-            expect(results).to include(process_group)
+            expect(results).to include(grouped_process)
           end
 
           it "does not return past processes" do
@@ -51,25 +52,48 @@ module Decidim
         context "when process_type is 'processes'" do
           let(:settings_hash) { super().merge(process_type: "processes") }
 
-          it "returns only processes" do
+          it "returns only processes without a group" do
             results = subject.results
             expect(results).to include(active_process)
-            expect(results).not_to include(process_group)
+            expect(results).not_to include(grouped_process)
+          end
+
+          context "when process_group_id is set (stale value from UI)" do
+            let(:settings_hash) { super().merge(process_type: "processes", process_group_id: process_group.id) }
+
+            it "ignores the group filter and returns ungrouped processes" do
+              results = subject.results
+              expect(results).to include(active_process)
+              expect(results).not_to include(grouped_process)
+            end
           end
         end
 
         context "when process_type is 'groups'" do
           let(:settings_hash) { super().merge(process_type: "groups") }
 
-          it "returns only groups" do
+          it "returns only processes with a group" do
             results = subject.results
-            expect(results).to include(process_group)
+            expect(results).to include(grouped_process)
             expect(results).not_to include(active_process)
+          end
+
+          context "when restricted to a specific group" do
+            let!(:other_group) { create(:participatory_process_group, organization:) }
+            let!(:other_grouped) { create(:participatory_process, :active, :published, organization:, participatory_process_group: other_group) }
+            let(:settings_hash) { super().merge(process_type: "groups", process_group_id: process_group.id) }
+
+            it "returns only processes from the specified group" do
+              results = subject.results
+              expect(results).to include(grouped_process)
+              expect(results).not_to include(other_grouped)
+              expect(results).not_to include(active_process)
+            end
           end
         end
 
         context "when process_status is 'all'" do
-          let(:settings_hash) { super().merge(process_type: "processes", process_status: "all") }
+          let(:settings_hash) { super().merge(process_status: "all") }
 
           it "returns both active and past processes" do
             results = subject.results
@@ -84,7 +108,7 @@ module Decidim
 
         context "when process_status is 'upcoming'" do
           let!(:upcoming_process) { create(:participatory_process, :upcoming, :published, organization:) }
-          let(:settings_hash) { super().merge(process_type: "processes", process_status: "upcoming") }
+          let(:settings_hash) { super().merge(process_status: "upcoming") }
 
           it "returns only upcoming processes" do
             results = subject.results
@@ -95,7 +119,7 @@ module Decidim
         end
 
         context "when process_status is 'past'" do
-          let(:settings_hash) { super().merge(process_type: "processes", process_status: "past") }
+          let(:settings_hash) { super().merge(process_status: "past") }
 
           it "returns only past processes" do
             results = subject.results
@@ -105,7 +129,7 @@ module Decidim
         end
 
         context "when process_status is 'active' (default)" do
-          let(:settings_hash) { super().merge(process_type: "processes", process_status: "active") }
+          let(:settings_hash) { super().merge(process_status: "active") }
 
           it "returns only active processes" do
             results = subject.results
@@ -114,14 +138,20 @@ module Decidim
           end
         end
 
-        context "when process_group_id is set to a specific group" do
-          let!(:grouped_process) { create(:participatory_process, :active, :published, organization:, participatory_process_group: process_group) }
+        context "when process_group_id is set (type: all)" do
           let(:settings_hash) { super().merge(process_group_id: process_group.id) }
 
-          it "filters processes by that group" do
+          it "shows processes from that group AND ungrouped processes" do
             results = subject.results
             expect(results).to include(grouped_process)
-            expect(results).not_to include(active_process)
+            expect(results).to include(active_process)
+          end
+
+          it "excludes processes from other groups" do
+            other_group = create(:participatory_process_group, organization:)
+            other_grouped = create(:participatory_process, :active, :published, organization:, participatory_process_group: other_group)
+            results = subject.results
+            expect(results).not_to include(other_grouped)
           end
         end
 
@@ -129,18 +159,17 @@ module Decidim
           let(:settings_hash) { super().merge(process_group_id: 0) }
 
           it "does not filter by group" do
-            expect(subject.results).to include(active_process)
+            results = subject.results
+            expect(results).to include(active_process)
+            expect(results).to include(grouped_process)
           end
         end
 
-        context "when max_results is 2" do
-          let(:settings_hash) { super().merge(max_results: 2) }
-
-          let!(:extra_process1) { create(:participatory_process, :active, :published, organization:) }
-          let!(:extra_process2) { create(:participatory_process, :active, :published, organization:) }
+        context "when max_results is 1" do
+          let(:settings_hash) { super().merge(max_results: 1) }
 
           it "limits total items returned" do
-            expect(subject.results.size).to be <= 2
+            expect(subject.results.size).to eq(1)
           end
         end
 
@@ -156,7 +185,6 @@ module Decidim
         context "when processes have different weights" do
           let!(:heavy_process) { create(:participatory_process, :active, :published, organization:, weight: 10) }
           let!(:light_process) { create(:participatory_process, :active, :published, organization:, weight: 1) }
-          let(:settings_hash) { super().merge(process_type: "processes") }
 
           it "sorts processes by weight ascending" do
             results = subject.results
@@ -167,75 +195,14 @@ module Decidim
         end
 
         context "when processes have the same weight" do
-          let!(:process_a) { create(:participatory_process, :active, :published, organization:, weight: 5) }
-          let!(:process_b) { create(:participatory_process, :active, :published, organization:, weight: 5) }
-          let(:settings_hash) { super().merge(process_type: "processes") }
+          let!(:first_process) { create(:participatory_process, :active, :published, organization:, weight: 1) }
+          let!(:second_process) { create(:participatory_process, :active, :published, organization:, weight: 1) }
 
-          it "uses id as tie-breaker" do
+          it "breaks ties by id ascending" do
             results = subject.results
-            idx_a = results.index(process_a)
-            idx_b = results.index(process_b)
-            if process_a.id < process_b.id
-              expect(idx_a).to be < idx_b
-            else
-              expect(idx_b).to be < idx_a
-            end
-          end
-        end
-
-        context "when process_type is 'all' (mixed interleaving)" do
-          let!(:process2) { create(:participatory_process, :active, :published, organization:, weight: 2) }
-          let!(:group2) { create(:participatory_process_group, organization:) }
-          let(:settings_hash) { super().merge(process_type: "all", max_results: 10) }
-
-          it "interleaves processes and groups" do
-            results = subject.results
-            process_indices = results.each_index.select { |i| results[i].is_a?(Decidim::ParticipatoryProcess) }
-            group_indices = results.each_index.select { |i| results[i].is_a?(Decidim::ParticipatoryProcessGroup) }
-
-            expect(process_indices).not_to be_empty
-            expect(group_indices).not_to be_empty
-            expect(results[0]).to be_a(Decidim::ParticipatoryProcess)
-            expect(results[1]).to be_a(Decidim::ParticipatoryProcessGroup)
-          end
-        end
-
-        context "when mixed with more processes than groups" do
-          let!(:process2) { create(:participatory_process, :active, :published, organization:, weight: 2) }
-          let!(:process3) { create(:participatory_process, :active, :published, organization:, weight: 3) }
-          let(:settings_hash) { super().merge(process_type: "all", max_results: 10) }
-
-          it "fills remaining slots with processes after groups run out" do
-            results = subject.results
-            processes = results.select { |r| r.is_a?(Decidim::ParticipatoryProcess) }
-            groups = results.select { |r| r.is_a?(Decidim::ParticipatoryProcessGroup) }
-            expect(processes.size).to eq(3)
-            expect(groups.size).to eq(1)
-            expect(results.size).to eq(4)
-          end
-        end
-
-        context "when mixed with more groups than processes" do
-          let!(:group2) { create(:participatory_process_group, organization:) }
-          let!(:group3) { create(:participatory_process_group, organization:) }
-          let(:settings_hash) { super().merge(process_type: "all", max_results: 10) }
-
-          it "fills remaining slots with groups after processes run out" do
-            results = subject.results
-            processes = results.select { |r| r.is_a?(Decidim::ParticipatoryProcess) }
-            groups = results.select { |r| r.is_a?(Decidim::ParticipatoryProcessGroup) }
-            expect(processes.size).to eq(1)
-            expect(groups.size).to eq(3)
-          end
-        end
-
-        context "when mixed with max_results limiting output" do
-          let!(:process2) { create(:participatory_process, :active, :published, organization:, weight: 2) }
-          let!(:group2) { create(:participatory_process_group, organization:) }
-          let(:settings_hash) { super().merge(process_type: "all", max_results: 3) }
-
-          it "respects max_results" do
-            expect(subject.results.size).to eq(3)
+            first_idx = results.index(first_process)
+            second_idx = results.index(second_process)
+            expect(first_idx).to be < second_idx
           end
         end
       end
@@ -253,46 +220,25 @@ module Decidim
         let(:selected_ids) { [] }
 
         context "with process IDs" do
-          let(:selected_ids) { ["process_#{active_process.id}"] }
+          let(:selected_ids) { [active_process.id.to_s] }
 
           it "returns those specific processes" do
             results = subject.results
             expect(results).to include(active_process)
-            expect(results).not_to include(past_process)
-          end
-        end
-
-        context "with group IDs" do
-          let(:selected_ids) { ["group_#{process_group.id}"] }
-
-          it "returns those specific groups" do
-            results = subject.results
-            expect(results).to include(process_group)
-            expect(results).not_to include(active_process)
-          end
-        end
-
-        context "with mix of process and group IDs" do
-          let(:selected_ids) { ["process_#{active_process.id}", "group_#{process_group.id}"] }
-
-          it "returns both types" do
-            results = subject.results
-            expect(results).to include(active_process)
-            expect(results).to include(process_group)
+            expect(results).not_to include(grouped_process)
           end
         end
 
         context "when order matters" do
-          let(:selected_ids) { ["group_#{process_group.id}", "process_#{active_process.id}", "process_#{past_process.id}"] }
+          let(:selected_ids) { [grouped_process.id.to_s, active_process.id.to_s] }
 
           it "preserves the order from selected_ids" do
-            results = subject.results
-            expect(results).to eq([process_group, active_process, past_process])
+            expect(subject.results).to eq([grouped_process, active_process])
           end
         end
 
         context "with blank entries" do
-          let(:selected_ids) { ["process_#{active_process.id}", "", " "] }
+          let(:selected_ids) { [active_process.id.to_s, "", " "] }
 
           it "ignores blank strings" do
             expect { subject.results }.not_to raise_error
@@ -301,7 +247,7 @@ module Decidim
         end
 
         context "with non-existent IDs" do
-          let(:selected_ids) { ["process_#{active_process.id}", "process_99999"] }
+          let(:selected_ids) { [active_process.id.to_s, "99999"] }
 
           it "returns only existing items" do
             results = subject.results
@@ -311,9 +257,7 @@ module Decidim
         end
 
         context "when max_results limits output" do
-          let(:selected_ids) do
-            ["process_#{active_process.id}", "process_#{past_process.id}", "group_#{process_group.id}"]
-          end
+          let(:selected_ids) { [active_process.id.to_s, grouped_process.id.to_s, past_process.id.to_s] }
           let(:settings_hash) { super().merge(max_results: 1) }
 
           it "limits output" do
@@ -322,18 +266,63 @@ module Decidim
         end
 
         context "when a past process is selected" do
-          let(:selected_ids) { ["process_#{past_process.id}"] }
+          let(:selected_ids) { [past_process.id.to_s] }
 
-          it "returns it (manual ignores active filter)" do
+          it "returns it (manual ignores status filter)" do
             expect(subject.results).to include(past_process)
           end
         end
 
         context "when an unpublished process is selected" do
-          let(:selected_ids) { ["process_#{unpublished_process.id}"] }
+          let(:selected_ids) { [unpublished_process.id.to_s] }
 
           it "does not return it" do
             expect(subject.results).not_to include(unpublished_process)
+          end
+        end
+
+        context "when restricted to a specific group (type: all)" do
+          let!(:other_process) { create(:participatory_process, :active, :published, organization:) }
+          let(:selected_ids) { [grouped_process.id.to_s, other_process.id.to_s] }
+          let(:settings_hash) { super().merge(process_group_id: process_group.id) }
+
+          it "includes grouped process and ungrouped process" do
+            results = subject.results
+            expect(results).to include(grouped_process)
+            expect(results).to include(other_process)
+          end
+        end
+
+        context "when restricted to a specific group (type: groups)" do
+          let!(:other_process) { create(:participatory_process, :active, :published, organization:) }
+          let(:selected_ids) { [grouped_process.id.to_s, other_process.id.to_s] }
+          let(:settings_hash) { super().merge(process_type: "groups", process_group_id: process_group.id) }
+
+          it "returns only processes from that group" do
+            results = subject.results
+            expect(results).to include(grouped_process)
+            expect(results).not_to include(other_process)
+          end
+        end
+
+        context "when process_type is 'processes'" do
+          let(:selected_ids) { [active_process.id.to_s, grouped_process.id.to_s] }
+          let(:settings_hash) { super().merge(process_type: "processes") }
+
+          it "returns only processes without a group" do
+            results = subject.results
+            expect(results).to include(active_process)
+            expect(results).not_to include(grouped_process)
+          end
+
+          context "when process_group_id is set (stale value from UI)" do
+            let(:settings_hash) { super().merge(process_type: "processes", process_group_id: process_group.id) }
+
+            it "ignores the group filter and returns ungrouped processes" do
+              results = subject.results
+              expect(results).to include(active_process)
+              expect(results).not_to include(grouped_process)
+            end
           end
         end
       end

--- a/spec/queries/decidim/decidim_awesome/awesome_processes_query_spec.rb
+++ b/spec/queries/decidim/decidim_awesome/awesome_processes_query_spec.rb
@@ -176,9 +176,9 @@ module Decidim
         context "when max_results is negative" do
           let(:settings_hash) { super().merge(max_results: -1) }
 
-          it "does not raise an error and returns an empty array" do
+          it "treats it as 1 and returns a single result" do
             expect { subject.results }.not_to raise_error
-            expect(subject.results).to eq([])
+            expect(subject.results.size).to eq(1)
           end
         end
 

--- a/spec/system/admin/admin_manages_awesome_processes_content_block_spec.rb
+++ b/spec/system/admin/admin_manages_awesome_processes_content_block_spec.rb
@@ -125,66 +125,156 @@ describe "Admin manages Awesome Processes content block" do
         end
       end
 
-      it "shows mixed hint when process_type is 'All processes and groups mixed'" do
-        expect(page).to have_select("content_block_settings_process_type", selected: "All processes and groups mixed")
+      it "shows mixed hint when process_type is 'All processes'" do
+        expect(page).to have_select("content_block_settings_process_type", selected: "All processes")
         within "[data-awesome-processes-type]" do
-          expect(page).to have_content("In mixed mode")
+          expect(page).to have_content("Shows all processes sorted")
         end
       end
 
       it "hides mixed hint when switching to 'Only processes'" do
         select "Only processes", from: "content_block_settings_process_type"
         within "[data-awesome-processes-type]" do
-          expect(page).to have_no_content("In mixed mode")
+          expect(page).to have_no_content("Shows all processes sorted")
         end
       end
 
-      it "hides mixed hint when switching to 'Only process groups'" do
-        select "Only process groups", from: "content_block_settings_process_type"
-        within "[data-awesome-processes-type]" do
-          expect(page).to have_no_content("In mixed mode")
-        end
-      end
-
-      it "shows mixed hint again when switching back to 'All'" do
+      it "hides group filter when switching to 'Only processes'" do
+        expect(page).to have_select("content_block_settings_process_group_id")
         select "Only processes", from: "content_block_settings_process_type"
-        within "[data-awesome-processes-type]" do
-          expect(page).to have_no_content("In mixed mode")
-        end
+        expect(page).to have_no_select("content_block_settings_process_group_id", visible: :visible)
+      end
 
-        select "All processes and groups mixed", from: "content_block_settings_process_type"
-        within "[data-awesome-processes-type]" do
-          expect(page).to have_content("In mixed mode")
-        end
+      it "shows group filter when switching back to 'All processes'" do
+        select "Only processes", from: "content_block_settings_process_type"
+        select "All processes", from: "content_block_settings_process_type"
+        expect(page).to have_select("content_block_settings_process_group_id")
       end
     end
 
-    describe "edge cases" do
-      context "when no process groups exist" do
-        before do
-          Decidim::ParticipatoryProcessGroup.where(organization:).destroy_all
-          visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
-        end
+    describe "manual selection filtering" do
+      let!(:group_a) { create(:participatory_process_group, organization:, title: { "en" => "Group Alpha" }) }
+      let!(:process_in_group) { create(:participatory_process, :active, :published, organization:, participatory_process_group: group_a, title: { "en" => "Process In Alpha" }) }
+      let!(:process_outside_group) { create(:participatory_process, :active, :published, organization:, title: { "en" => "Process Outside" }) }
+      let!(:past_grouped_process) { create(:participatory_process, :past, :published, organization:, participatory_process_group: group_a, title: { "en" => "Past In Alpha" }) }
 
-        it "shows only 'Any group' option in the process group select" do
-          options = all("#content_block_settings_process_group_id option")
-          expect(options.size).to eq(1)
-          expect(options.first.text).to eq("Any group")
+      before do
+        # Revisit page so newly created groups/processes appear in the form
+        visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
+        select "Manual", from: "content_block_settings_selection_criteria"
+      end
+
+      def open_tom_select
+        find("[data-awesome-processes-manual] .ts-control input").click
+      end
+
+      it "filters processes by group when a group is selected" do
+        select "Group Alpha", from: "content_block_settings_process_group_id"
+        open_tom_select
+
+        within ".ts-dropdown" do
+          expect(page).to have_content("Process In Alpha")
+          expect(page).to have_no_content("Process Outside")
         end
       end
 
-      context "when no published processes and no groups exist" do
-        before do
-          Decidim::ParticipatoryProcess.where(organization:).destroy_all
-          Decidim::ParticipatoryProcessGroup.where(organization:).destroy_all
-          visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
-        end
+      it "shows all processes when 'Any group' is selected" do
+        select "All processes", from: "content_block_settings_process_status"
+        select "Any group", from: "content_block_settings_process_group_id"
+        open_tom_select
 
-        it "has empty manual multiselect" do
-          select "Manual", from: "content_block_settings_selection_criteria"
-          options = all("[data-awesome-processes-manual] select option")
-          expect(options).to be_empty
+        within ".ts-dropdown" do
+          expect(page).to have_content("Process In Alpha")
+          expect(page).to have_content("Process Outside")
         end
+      end
+
+      it "filters processes by status" do
+        select "Group Alpha", from: "content_block_settings_process_group_id"
+        select "All processes", from: "content_block_settings_process_status"
+        open_tom_select
+
+        within ".ts-dropdown" do
+          expect(page).to have_content("Process In Alpha")
+          expect(page).to have_content("Past In Alpha")
+        end
+      end
+
+      it "filters by process type" do
+        select "All processes", from: "content_block_settings_process_status"
+        select "Only processes", from: "content_block_settings_process_type"
+        open_tom_select
+
+        within ".ts-dropdown" do
+          expect(page).to have_content("Process Outside")
+          expect(page).to have_no_content("Process In Alpha")
+        end
+      end
+
+      it "preserves selected items when filters change" do
+        # Select a process first
+        open_tom_select
+        find(".ts-dropdown .option", text: "Process In Alpha").click
+
+        # Change filter to a different group — selected item should stay
+        select "Any group", from: "content_block_settings_process_group_id"
+
+        within "[data-awesome-processes-manual] .ts-control" do
+          expect(page).to have_content("Process In Alpha")
+        end
+      end
+
+      it "reorders items with arrow buttons and persists order after save" do
+        open_tom_select
+        find(".ts-dropdown .option", text: "Process In Alpha").click
+        open_tom_select
+        find(".ts-dropdown .option", text: "Process Outside").click
+
+        # Move second item up
+        items = all("[data-awesome-processes-manual] .ts-control [data-value]")
+        expect(items[0]).to have_content("Process In Alpha")
+        expect(items[1]).to have_content("Process Outside")
+
+        items[1].find(".reorder-up").click
+
+        items = all("[data-awesome-processes-manual] .ts-control [data-value]")
+        expect(items[0]).to have_content("Process Outside")
+        expect(items[1]).to have_content("Process In Alpha")
+
+        # Save and reload
+        click_link_or_button "Update"
+        visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
+        select "Manual", from: "content_block_settings_selection_criteria"
+
+        items = all("[data-awesome-processes-manual] .ts-control [data-value]")
+        expect(items[0]).to have_content("Process Outside")
+        expect(items[1]).to have_content("Process In Alpha")
+      end
+    end
+
+    context "when no process groups exist" do
+      before do
+        Decidim::ParticipatoryProcessGroup.where(organization:).destroy_all
+        visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
+      end
+
+      it "shows only 'Any group' option in the process group select" do
+        options = all("#content_block_settings_process_group_id option")
+        expect(options.size).to eq(1)
+        expect(options.first.text).to eq("Any group")
+      end
+    end
+
+    context "when no published processes exist" do
+      before do
+        Decidim::ParticipatoryProcess.where(organization:).destroy_all
+        visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
+      end
+
+      it "has empty manual multiselect" do
+        select "Manual", from: "content_block_settings_selection_criteria"
+        options = all("[data-awesome-processes-manual] select option")
+        expect(options).to be_empty
       end
     end
   end

--- a/spec/system/admin/admin_manages_awesome_processes_content_block_spec.rb
+++ b/spec/system/admin/admin_manages_awesome_processes_content_block_spec.rb
@@ -128,14 +128,14 @@ describe "Admin manages Awesome Processes content block" do
       it "shows mixed hint when process_type is 'All processes'" do
         expect(page).to have_select("content_block_settings_process_type", selected: "All processes")
         within "[data-awesome-processes-type]" do
-          expect(page).to have_content("Shows all processes sorted")
+          expect(page).to have_content("Shows all processes up to the maximum amount")
         end
       end
 
       it "hides mixed hint when switching to 'Only processes'" do
         select "Only processes", from: "content_block_settings_process_type"
         within "[data-awesome-processes-type]" do
-          expect(page).to have_no_content("Shows all processes sorted")
+          expect(page).to have_no_content("Shows all processes up to the maximum amount")
         end
       end
 
@@ -168,7 +168,8 @@ describe "Admin manages Awesome Processes content block" do
         find("[data-awesome-processes-manual] .ts-control input").click
       end
 
-      it "filters processes by group when a group is selected" do
+      it "filters processes by group when type is 'groups' and a group is selected" do
+        select "Only process groups", from: "content_block_settings_process_type"
         select "Group Alpha", from: "content_block_settings_process_group_id"
         open_tom_select
 
@@ -227,7 +228,13 @@ describe "Admin manages Awesome Processes content block" do
       it "reorders items with arrow buttons and persists order after save" do
         open_tom_select
         find(".ts-dropdown .option", text: "Process In Alpha").click
-        open_tom_select
+
+        within "[data-awesome-processes-manual] .ts-control" do
+          expect(page).to have_content("Process In Alpha")
+        end
+
+        # Type in the search to re-open dropdown and find the second process
+        find("[data-awesome-processes-manual] .ts-control input").fill_in with: "Outside"
         find(".ts-dropdown .option", text: "Process Outside").click
 
         # Move second item up

--- a/spec/system/public/awesome_processes_content_block_spec.rb
+++ b/spec/system/public/awesome_processes_content_block_spec.rb
@@ -7,18 +7,20 @@ describe "Public homepage shows Awesome Processes block" do
 
   let!(:content_block) { create(:content_block, organization:, manifest_name: :awesome_processes, scope_name: :homepage, settings:) }
   let(:settings) { {} }
-  let!(:active_process) { create(:participatory_process, :active, :published, organization:) }
-  let!(:past_process) { create(:participatory_process, :past, :published, organization:) }
   let!(:process_group) { create(:participatory_process_group, organization:) }
+  let!(:active_process) { create(:participatory_process, :active, :published, organization:) }
+  let!(:grouped_process) { create(:participatory_process, :active, :published, organization:, participatory_process_group: process_group) }
+  let!(:past_process) { create(:participatory_process, :past, :published, organization:) }
 
   before do
     switch_to_host(organization.host)
   end
 
-  context "when block is active with active processes" do
-    it "displays processes on homepage" do
+  context "when block is active with default settings" do
+    it "displays active processes on homepage" do
       visit decidim.root_path
       expect(page).to have_content(translated(active_process.title))
+      expect(page).to have_content(translated(grouped_process.title))
     end
   end
 
@@ -34,35 +36,61 @@ describe "Public homepage shows Awesome Processes block" do
   context "when process_type is 'processes'" do
     let(:settings) { { process_type: "processes" } }
 
-    it "shows only processes, not groups" do
+    it "shows only processes without a group" do
       visit decidim.root_path
       expect(page).to have_content(translated(active_process.title))
-      expect(page).to have_no_content(translated(process_group.title))
+      expect(page).to have_no_content(translated(grouped_process.title))
     end
   end
 
   context "when process_type is 'groups'" do
     let(:settings) { { process_type: "groups" } }
 
-    it "shows only groups" do
+    it "shows individual processes that belong to groups" do
       visit decidim.root_path
-      expect(page).to have_content(translated(process_group.title))
+      expect(page).to have_content(translated(grouped_process.title))
       expect(page).to have_no_content(translated(active_process.title))
+    end
+
+    context "when restricted to a specific group" do
+      let!(:other_group) { create(:participatory_process_group, organization:) }
+      let!(:other_grouped) { create(:participatory_process, :active, :published, organization:, participatory_process_group: other_group) }
+      let(:settings) { { process_type: "groups", process_group_id: process_group.id } }
+
+      it "shows only processes from that group" do
+        visit decidim.root_path
+        expect(page).to have_content(translated(grouped_process.title))
+        expect(page).to have_no_content(translated(other_grouped.title))
+        expect(page).to have_no_content(translated(active_process.title))
+      end
     end
   end
 
-  context "when process_type is 'all' (mixed)" do
+  context "when process_type is 'all'" do
     let(:settings) { { process_type: "all", max_results: 10 } }
 
-    it "shows both processes and groups" do
+    it "shows all processes regardless of group" do
       visit decidim.root_path
       expect(page).to have_content(translated(active_process.title))
-      expect(page).to have_content(translated(process_group.title))
+      expect(page).to have_content(translated(grouped_process.title))
+    end
+
+    context "when restricted to a specific group" do
+      let!(:other_group) { create(:participatory_process_group, organization:) }
+      let!(:other_grouped) { create(:participatory_process, :active, :published, organization:, participatory_process_group: other_group) }
+      let(:settings) { { process_type: "all", process_group_id: process_group.id, max_results: 10 } }
+
+      it "shows processes from that group and ungrouped processes" do
+        visit decidim.root_path
+        expect(page).to have_content(translated(grouped_process.title))
+        expect(page).to have_content(translated(active_process.title))
+        expect(page).to have_no_content(translated(other_grouped.title))
+      end
     end
   end
 
   context "when process_status is 'all'" do
-    let(:settings) { { process_type: "processes", process_status: "all" } }
+    let(:settings) { { process_status: "all" } }
 
     it "shows both active and past processes" do
       visit decidim.root_path
@@ -72,7 +100,7 @@ describe "Public homepage shows Awesome Processes block" do
   end
 
   context "when process_status is 'past'" do
-    let(:settings) { { process_type: "processes", process_status: "past" } }
+    let(:settings) { { process_status: "past" } }
 
     it "shows only past processes" do
       visit decidim.root_path
@@ -81,15 +109,24 @@ describe "Public homepage shows Awesome Processes block" do
     end
   end
 
+  context "when process_status is 'upcoming'" do
+    let!(:upcoming_process) { create(:participatory_process, :upcoming, :published, organization:) }
+    let(:settings) { { process_status: "upcoming" } }
+
+    it "shows only upcoming processes" do
+      visit decidim.root_path
+      expect(page).to have_content(translated(upcoming_process.title))
+      expect(page).to have_no_content(translated(active_process.title))
+      expect(page).to have_no_content(translated(past_process.title))
+    end
+  end
+
   context "when max_results is 1" do
     let(:settings) { { max_results: 1 } }
-    let!(:another_active_process) { create(:participatory_process, :active, :published, organization:) }
 
     it "shows only 1 item" do
       visit decidim.root_path
       expect(page).to have_css(".card__grid-home > *", count: 1)
-      expect(page).to have_content(translated(active_process.title))
-      expect(page).to have_no_content(translated(another_active_process.title))
     end
   end
 
@@ -97,13 +134,31 @@ describe "Public homepage shows Awesome Processes block" do
     let(:settings) do
       {
         selection_criteria: "manual",
-        selected_ids: ["process_#{active_process.id}"]
+        selected_ids: [active_process.id.to_s]
       }
     end
 
     it "shows only selected processes" do
       visit decidim.root_path
       expect(page).to have_content(translated(active_process.title))
+    end
+
+    context "when restricted to a specific group (type: groups)" do
+      let!(:other_process) { create(:participatory_process, :active, :published, organization:) }
+      let(:settings) do
+        {
+          selection_criteria: "manual",
+          process_type: "groups",
+          process_group_id: process_group.id,
+          selected_ids: [grouped_process.id.to_s, other_process.id.to_s]
+        }
+      end
+
+      it "shows only processes from the restricted group" do
+        visit decidim.root_path
+        expect(page).to have_content(translated(grouped_process.title))
+        expect(page).to have_no_content(translated(other_process.title))
+      end
     end
   end
 
@@ -114,10 +169,9 @@ describe "Public homepage shows Awesome Processes block" do
       Decidim::ParticipatoryProcess.where(organization:).destroy_all
     end
 
-    it "does not show the block section or any process content" do
+    it "does not show the block section" do
       visit decidim.root_path
       expect(page).to have_no_css(".card__grid-home")
-      expect(page).to have_no_content(translated(active_process.title))
     end
   end
 
@@ -132,10 +186,8 @@ describe "Public homepage shows Awesome Processes block" do
     end
   end
 
-  context "when 'See all processes' link is present" do
-    it "links to participatory processes index" do
-      visit decidim.root_path
-      expect(page).to have_link("See all processes")
-    end
+  it "shows 'See all processes' link" do
+    visit decidim.root_path
+    expect(page).to have_link("See all processes")
   end
 end


### PR DESCRIPTION
Fixes #547, #548 

- Process type filter now correctly distinguishes between ungrouped processes, grouped processes, and all processes
- "Restrict to process group" filters only grouped processes; ungrouped processes always pass through in "All" mode
- Manual selection TomSelect dynamically filters options by type, group, and status
- Selected items are preserved when filters change
- Added reorder buttons (↑↓) to manually sort selected processes
- Order persists across page reloads
- Group cards are no longer displayed — always individual process cards
- "Restrict to process group" field is hidden when type is "Only processes"

Test plan

- Set type to "Only process groups", restrict to a group → homepage shows individual processes from that group
- Set type to "All processes", restrict to a group → homepage shows processes from that group + ungrouped processes
- Switch to manual, change filters → TomSelect options update, already selected items stay
- Reorder items with ↑↓ buttons, save → order preserved on reload and homepage