### PR TITLE
Allow custom redirects to be to external destinations

### DIFF
--- a/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
@@ -34,7 +34,7 @@ module Decidim
 
         def redirect_to_custom_paths
           destination = custom_redirects_destination(request.original_fullpath)
-          redirect_to destination if destination.present?
+          redirect_to(destination, allow_other_host: true) if destination.present?
         end
 
         def custom_redirects_destination(fullpath)

--- a/spec/system/public/custom_redirects_spec.rb
+++ b/spec/system/public/custom_redirects_spec.rb
@@ -90,6 +90,16 @@ describe "Custom Redirections" do
           end
         end
       end
+
+      context "when destination is an external URL" do
+        let(:destination) { "https://www.example.com" }
+
+        it "redirects to destination" do
+          visit goto
+
+          expect(page).to have_current_path("#{destination}?#{query}")
+        end
+      end
     end
 
     context "when origin is malformed" do


### PR DESCRIPTION
Currently the custom redirects does not warn that it does not work with external hosts.

This PR changes it. It's not meant to be merged yet.

I think there are two other solutions:

1. Add a checkbox to the custom redirect so that the admin aknowledges that it's an external domain.
2. Make the redirect work just as with this PR.

Or

1. Force external redirections to work as with any external link inside the decidim application.