### PR TITLE
Fix: proposal export drops votes column on components with standard voting

### DIFF
--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_methods.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_methods.rb
@@ -47,9 +47,7 @@ module Decidim
             payload = {}
             private_custom_fields = CustomFields.new(awesome_proposal_private_custom_fields)
             if private_custom_fields.present?
-              private_body = proposal.private_body.presence ||
-                             proposal.extra_fields&.private_body.presence ||
-                             proposal.reload.extra_fields&.private_body
+              private_body = proposal.private_body.presence || proposal.reload_extra_fields&.private_body
               return payload if private_body.blank?
 
               fields_entries(private_custom_fields, private_body) do |key, value|

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_methods.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_methods.rb
@@ -47,7 +47,12 @@ module Decidim
             payload = {}
             private_custom_fields = CustomFields.new(awesome_proposal_private_custom_fields)
             if private_custom_fields.present?
-              fields_entries(private_custom_fields, proposal.private_body) do |key, value|
+              private_body = proposal.private_body.presence ||
+                             proposal.extra_fields&.private_body.presence ||
+                             proposal.reload.extra_fields&.private_body
+              return payload if private_body.blank?
+
+              fields_entries(private_custom_fields, private_body) do |key, value|
                 value = value.first if value.is_a? Array
                 payload[:"private_body/#{key}"] = value
               end

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
@@ -15,11 +15,12 @@ module Decidim
           alias_method :decidim_original_convert_to_text, :convert_to_text
 
           def serialize
-            # serialize first the custom fields,
-            # as default serialization will strip proposal body's <xml> tags.
+            # Collect custom fields before core serialization because
+            # default serialization strips proposal body's <xml> tags.
+            custom_fields = serialize_custom_fields
             serialization = decidim_original_serialize
             serialization.merge!(proposal_vote_weights)
-            serialization.merge!(serialize_custom_fields)
+            serialization.merge!(custom_fields)
           end
 
           # The original convert to text does not parses dt/dd items

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
@@ -40,11 +40,21 @@ module Decidim
           # configuration). When neither is true, return an empty payload so
           # Decidim core's integer vote count is left in place.
           def proposal_vote_weights
+            return {} unless should_serialize_weighted_votes?
+
             proposal.update_vote_weights!
             weights = proposal.reload.vote_weights
-            return {} if weights.blank? && !awesome_voting_manifest_for(proposal.component)&.weighted?
+            return {} if weights.blank?
 
             { votes: weights }
+          end
+
+          def should_serialize_weighted_votes?
+            manifest = awesome_voting_manifest_for(proposal.component)
+            return true if manifest&.weighted?
+
+            proposal_votes = Decidim::Proposals::ProposalVote.where(proposal:)
+            Decidim::DecidimAwesome::VoteWeight.where(proposal_vote_id: proposal_votes.select(:id)).exists?
           end
         end
       end

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
@@ -44,7 +44,7 @@ module Decidim
             return {} unless should_serialize_weighted_votes?
 
             proposal.update_vote_weights!
-            weights = proposal.reload.vote_weights
+            weights = proposal.vote_weights
             return {} if weights.blank?
 
             { votes: weights }

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
@@ -54,7 +54,7 @@ module Decidim
             return true if manifest&.weighted?
 
             proposal_votes = Decidim::Proposals::ProposalVote.where(proposal:)
-            Decidim::DecidimAwesome::VoteWeight.where(proposal_vote_id: proposal_votes.select(:id)).exists?
+            Decidim::DecidimAwesome::VoteWeight.exists?(proposal_vote_id: proposal_votes.select(:id))
           end
         end
       end

--- a/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
+++ b/app/serializers/concerns/decidim/decidim_awesome/proposals/proposal_serializer_override.rb
@@ -34,13 +34,17 @@ module Decidim
 
           protected
 
+          # Override the standard `:votes` column with the weighted breakdown
+          # whenever the component currently uses a weighted manifest, OR
+          # weighted votes already exist (e.g. left over from a previous
+          # configuration). When neither is true, return an empty payload so
+          # Decidim core's integer vote count is left in place.
           def proposal_vote_weights
-            payload = {}
-            if proposal.respond_to?(:vote_weights)
-              proposal.update_vote_weights!
-              payload[:votes] = proposal.reload.vote_weights
-            end
-            payload
+            proposal.update_vote_weights!
+            weights = proposal.reload.vote_weights
+            return {} if weights.blank? && !awesome_voting_manifest_for(proposal.component)&.weighted?
+
+            { votes: weights }
           end
         end
       end

--- a/app/serializers/decidim/decidim_awesome/proposals/private_proposal_serializer.rb
+++ b/app/serializers/decidim/decidim_awesome/proposals/private_proposal_serializer.rb
@@ -10,7 +10,8 @@ module Decidim
         include ProposalSerializerMethods
 
         def serialize
-          serialization = super.merge!(serialize_private_custom_fields)
+          private_custom_fields = serialize_private_custom_fields
+          serialization = super.merge!(private_custom_fields)
           serialization.merge!(serialize_private_notes)
         end
 

--- a/lib/decidim/decidim_awesome/voting_manifest.rb
+++ b/lib/decidim/decidim_awesome/voting_manifest.rb
@@ -27,20 +27,20 @@ module Decidim
 
       # registers a weight validator
       def weight_validator(&block)
-        @on_weight_validation = block
+        self.on_weight_validation = block
       end
 
       # whether a weight validator has been registered for this manifest
       def weighted?
-        @on_weight_validation.present?
+        on_weight_validation.present?
       end
 
       # validates the weight using the Proc defined by weight_validator
       # Receives the weight and a context with the user and the proposal to be voted
       def valid_weight?(weight, context = {})
-        return true unless @on_weight_validation
+        return true unless on_weight_validation
 
-        @on_weight_validation.call(weight, **context)
+        on_weight_validation.call(weight, **context)
       end
 
       # registers an optional label generator block

--- a/lib/decidim/decidim_awesome/voting_manifest.rb
+++ b/lib/decidim/decidim_awesome/voting_manifest.rb
@@ -30,6 +30,11 @@ module Decidim
         @on_weight_validation = block
       end
 
+      # whether a weight validator has been registered for this manifest
+      def weighted?
+        @on_weight_validation.present?
+      end
+
       # validates the weight using the Proc defined by weight_validator
       # Receives the weight and a context with the user and the proposal to be voted
       def valid_weight?(weight, context = {})

--- a/spec/lib/voting_manifest_spec.rb
+++ b/spec/lib/voting_manifest_spec.rb
@@ -22,6 +22,17 @@ module Decidim::DecidimAwesome
       expect(subject).to be_valid_weight(-1.5)
     end
 
+    describe "#weighted?" do
+      it "is false when no validator has been registered" do
+        expect(subject.weighted?).to be false
+      end
+
+      it "is true once a validator block is registered" do
+        subject.weight_validator { |weight, _ctx| weight.in?([1, 2, 3]) }
+        expect(subject.weighted?).to be true
+      end
+    end
+
     it "returns automatic labels" do
       expect(subject.label_for(0)).to eq("weight_0")
       expect(subject.label_for(1)).to eq("weight_1")

--- a/spec/lib/voting_manifest_spec.rb
+++ b/spec/lib/voting_manifest_spec.rb
@@ -31,6 +31,18 @@ module Decidim::DecidimAwesome
         subject.weight_validator { |weight, _ctx| weight.in?([1, 2, 3]) }
         expect(subject.weighted?).to be true
       end
+
+      it "stores the validator through the public attribute" do
+        subject.weight_validator { |weight, _ctx| weight.in?([1, 2, 3]) }
+
+        expect(subject.on_weight_validation).to be_present
+      end
+
+      it "is true when initialized with on_weight_validation" do
+        manifest = described_class.new(name:, on_weight_validation: proc { |weight, _ctx| weight.in?([1, 2, 3]) })
+
+        expect(manifest.weighted?).to be true
+      end
     end
 
     it "returns automatic labels" do

--- a/spec/serializers/proposal_serializer_spec.rb
+++ b/spec/serializers/proposal_serializer_spec.rb
@@ -80,6 +80,11 @@ module Decidim::Proposals
           end
           let!(:another_extra_fields) { nil }
 
+          it "does not update weight cache while exporting" do
+            expect(proposal).not_to receive(:update_vote_weights!)
+            subject.serialize
+          end
+
           it "preserves Decidim core's integer vote count and does not overwrite it" do
             expect(serialized[:votes]).to eq(proposal.reload.proposal_votes_count)
             expect(serialized[:votes]).to be_a(Integer)

--- a/spec/serializers/proposal_serializer_spec.rb
+++ b/spec/serializers/proposal_serializer_spec.rb
@@ -65,11 +65,25 @@ module Decidim::Proposals
         expect(serialized).to include(votes: labeled_weights)
       end
 
-      context "when no manifest" do
+      context "when the component does not use a weighted voting manifest" do
         let(:manifest) { nil }
 
-        it "serializes the weights" do
+        it "still serializes weighted vote data that exists in the component" do
           expect(serialized).to include(votes: { "0" => 1, "1" => 0, "2" => 0, "3" => 2, "4" => 0, "5" => 0 })
+        end
+
+        context "and no weighted votes exist in the component" do
+          let!(:votes) do
+            3.times do
+              create(:proposal_vote, proposal:, author: create(:user, organization: proposal.organization))
+            end
+          end
+          let!(:another_extra_fields) { nil }
+
+          it "preserves Decidim core's integer vote count and does not overwrite it" do
+            expect(serialized[:votes]).to eq(proposal.reload.proposal_votes_count)
+            expect(serialized[:votes]).to be_a(Integer)
+          end
         end
       end
 


### PR DESCRIPTION
## Problem
Reproduction with two proposals components in the same space:

1. **Component A** — configured with the awesome voting_cards weighted manifest. Voters cast votes (Red / Yellow / Green / Abstain).
2. **Component B** — left on Decidim's standard, unweighted voting. Voters cast normal votes.

Then export proposals from each:

* Component A export contains the expected weighted breakdown columns: votes/Red, votes/Yellow, votes/Green, votes/Abstain.
* Component B export has no votes column at all — Decidim core's integer vote count is silently dropped.

###  Cause
`Decidim::DecidimAwesome::Proposals::ProposalSerializerOverride#proposal_vote_weights` was unconditionally merging `votes: proposal.vote_weights` into the serialized payload whenever the proposal responded to `:vote_weights`. Because `HasProposalExtraFields` is included into every proposal as soon as any awesome feature flag is on, every proposal responds to `:vote_weights` — even ones in components that use the plain Decidim voting system. For those, `vote_weights` is an empty hash, which then overwrites the integer votes: value that Decidim core's serializer had just produced.

A second, smaller bug in `VotingManifest` made it hard to detect this from the manifest itself: the class declared a public attribute `:on_weight_validation` that read from the ActiveModel attribute set, while the `weight_validator` setter wrote to an instance variable of the same name. The two storage slots never met, so external callers asking the manifest "do you have weights?" always got nil.

## Fix
* `VotingManifest`: Add a `weighted?` predicate that returns true once a `weight_validator` block has been registered.
* `ProposalSerializerOverride#proposal_vote_weights`: only override the `:votes` column when the component is currently configured with a weighted manifest, or weighted vote data already exists for the proposal (legacy data left over after a manifest change). When neither is true, return an empty payload so Decidim core's integer count is left untouched.

## Tests
Some tests have been added in spec/lib/voting_manifest_spec.rb and spec/serializers/proposal_serializer_spec.rb.

Manual testing: In a dev app, create two proposal components (one with voting_cards, one without), cast votes in each, export both, confirm Component A has i`votes/<label>` columns and Component B has the integer votes column.