### PR TITLE
Add "Not answered" at voting by status in proposals

### DIFF
--- a/app/helpers/concerns/decidim/decidim_awesome/admin/settings_helper_override.rb
+++ b/app/helpers/concerns/decidim/decidim_awesome/admin/settings_helper_override.rb
@@ -41,7 +41,10 @@ module Decidim
               { include_blank: false, label: options[:label] },
               html_options
             )
-            select_html << content_tag(:p, options[:help_text], class: "help-text") if options[:help_text]
+            # Help only matters before save (when the list shows just "Not answered"); hide it for persisted components.
+            help_text = options[:help_text]
+            help_text = nil if name.to_sym == :awesome_votes_enabled_states && @component&.persisted?
+            select_html << content_tag(:p, help_text, class: "help-text") if help_text
             select_html
           end
         end

--- a/app/services/decidim/decidim_awesome/proposals/votes_by_proposal_status.rb
+++ b/app/services/decidim/decidim_awesome/proposals/votes_by_proposal_status.rb
@@ -3,9 +3,7 @@
 module Decidim
   module DecidimAwesome
     module Proposals
-      # Shared logic for the "votes by proposal status" filter.
-      # Used by both Decidim::Proposals::Permissions and the view helpers so
-      # the rule lives in a single place.
+      # "Votes by proposal status" filter logic, shared by Permissions and view helpers.
       class VotesByProposalStatus
         def initialize(settings)
           @settings = settings
@@ -16,18 +14,27 @@ module Decidim
           return false unless @settings.try(:votes_enabled)
           return false unless @settings.try(:awesome_votes_enabled_by_status)
 
-          allowed_state_ids.any?
+          allowed_tokens.any?
         end
 
         def allowed?(proposal)
-          state_id = proposal&.decidim_proposals_proposal_state_id
-          return false unless state_id
+          return false unless proposal
 
-          allowed_state_ids.include?(state_id.to_i)
+          allowed_tokens.include?(proposal.internal_state)
         end
 
-        def allowed_state_ids
-          @allowed_state_ids ||= Array(@settings.try(:awesome_votes_enabled_states)).compact_blank.map(&:to_i)
+        def allowed_tokens
+          @allowed_tokens ||= Array(@settings.try(:awesome_votes_enabled_states)).compact_blank.map(&:to_s)
+        end
+
+        # [label, token] pairs for the admin multiselect: synthetic "not_answered" first, then real states.
+        def self.choices_for(component)
+          not_answered = [I18n.t("decidim.proposals.answers.not_answered"), "not_answered"]
+          real_states = Decidim::Proposals::ProposalState
+                        .where(component:)
+                        .where.not(token: "not_answered")
+                        .map { |state| [state.translated_attribute(state.title), state.token] }
+          [not_answered] + real_states
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
               will not accept votes. Leave empty to allow voting on all proposals
               regardless of status.
             awesome_votes_enabled_states: Allowed statuses for votes
-            awesome_votes_enabled_states_help: Other statuses become available after
+            awesome_votes_enabled_states_help: Other statuses will become available after
               the component is saved.
             default_sort_order_options:
               az: A-Z (Alphabetical)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,8 @@ en:
               will not accept votes. Leave empty to allow voting on all proposals
               regardless of status.
             awesome_votes_enabled_states: Allowed statuses for votes
+            awesome_votes_enabled_states_help: Other statuses become available after
+              the component is saved.
             default_sort_order_options:
               az: A-Z (Alphabetical)
               supported_first: Supported first
@@ -1245,7 +1247,7 @@ en:
       proposal_private_custom_fields_disclosure: This information won't be published
       proposals:
         votes:
-          blocked_by_status: Voting unavailable
+          blocked_by_status: Not accepted for voting
       required_authorizations:
         index:
           authorization_options_invalid: Unfortunately, although you have this authorization,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,8 +202,8 @@ en:
               will not accept votes. Leave empty to allow voting on all proposals
               regardless of status.
             awesome_votes_enabled_states: Allowed statuses for votes
-            awesome_votes_enabled_states_help: Other statuses will become available after
-              the component is saved.
+            awesome_votes_enabled_states_help: Other statuses will become available
+              after the component is saved.
             default_sort_order_options:
               az: A-Z (Alphabetical)
               supported_first: Supported first
@@ -1247,7 +1247,7 @@ en:
       proposal_private_custom_fields_disclosure: This information won't be published
       proposals:
         votes:
-          blocked_by_status: Not accepted for voting
+          blocked_by_status: Voting unavailable
       required_authorizations:
         index:
           authorization_options_invalid: Unfortunately, although you have this authorization,

--- a/docs/tweaks/proposals-participation.md
+++ b/docs/tweaks/proposals-participation.md
@@ -252,8 +252,8 @@ Restricts proposal voting to proposals whose state is in an admin-selected list.
 
 #### Admin description
 
-Allows admins to restrict supports to a selected subset of proposal states (for example, only "Accepted" or "Evaluating"). This configuration is available per step configuration in participatory processes.
-Note: proposals outside the allowed states display a "Voting unavailable" message, with no "disabled" button for voting.
+Allows admins to restrict supports to a selected subset of proposal states (for example, only "Accepted" or "Evaluating"). The list also includes "Not answered" so admins can allow (or restrict) votes on proposals that have not received an admin answer yet. This configuration is available per step configuration in participatory processes.
+Note: proposals outside the allowed states display a "Not accepted for voting" message, with no "disabled" button for voting.
 
 #### Technical area
 

--- a/docs/tweaks/proposals-participation.md
+++ b/docs/tweaks/proposals-participation.md
@@ -253,7 +253,7 @@ Restricts proposal voting to proposals whose state is in an admin-selected list.
 #### Admin description
 
 Allows admins to restrict supports to a selected subset of proposal states (for example, only "Accepted" or "Evaluating"). The list also includes "Not answered" so admins can allow (or restrict) votes on proposals that have not received an admin answer yet. This configuration is available per step configuration in participatory processes.
-Note: proposals outside the allowed states display a "Not accepted for voting" message, with no "disabled" button for voting.
+Note: proposals outside the allowed states display a "Voting unavailable" message, with no "disabled" button for voting.
 
 #### Technical area
 

--- a/lib/decidim/decidim_awesome/engine.rb
+++ b/lib/decidim/decidim_awesome/engine.rb
@@ -228,7 +228,7 @@ module Decidim
                     component = context && context[:component]
                     next [] unless component
 
-                    Decidim::Proposals::ProposalState.where(component:).map { |state| [state.translated_attribute(state.title), state.id.to_s] }
+                    Decidim::DecidimAwesome::Proposals::VotesByProposalStatus.choices_for(component)
                   }
                 )
               )

--- a/spec/helpers/awesome_helpers_spec.rb
+++ b/spec/helpers/awesome_helpers_spec.rb
@@ -125,8 +125,6 @@ module Decidim::DecidimAwesome
 
       let(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
       let(:filter_component) { create(:proposal_component, participatory_space: participatory_process) }
-      let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component: filter_component, token: "accepted") }
-      let(:rejected_state) { Decidim::Proposals::ProposalState.find_by(component: filter_component, token: "rejected") }
       let(:proposal) { create(:proposal, component: filter_component, state: "accepted") }
 
       let(:step_settings) { {} }
@@ -136,7 +134,7 @@ module Decidim::DecidimAwesome
       end
 
       context "when the global feature flag is disabled" do
-        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [rejected_state.id.to_s] } }
+        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(rejected) } }
 
         before { allow(Decidim::DecidimAwesome.config).to receive(:votes_by_proposal_status).and_return(:disabled) }
 
@@ -145,14 +143,14 @@ module Decidim::DecidimAwesome
 
       context "when votes are blocked at the step level" do
         let(:step_settings) do
-          { votes_enabled: true, votes_blocked: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [rejected_state.id.to_s] }
+          { votes_enabled: true, votes_blocked: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(rejected) }
         end
 
         it { is_expected.to be(false) }
       end
 
       context "when votes are not enabled on the step" do
-        let(:step_settings) { { votes_enabled: false, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [rejected_state.id.to_s] } }
+        let(:step_settings) { { votes_enabled: false, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(rejected) } }
 
         it { is_expected.to be(false) }
       end
@@ -170,27 +168,34 @@ module Decidim::DecidimAwesome
       end
 
       context "when the filter is enabled and the proposal status is in the allowed list" do
-        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [accepted_state.id.to_s] } }
+        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(accepted) } }
 
         it { is_expected.to be(false) }
       end
 
       context "when the filter is enabled and the proposal status is not in the allowed list" do
-        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [rejected_state.id.to_s] } }
+        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(rejected) } }
 
         it { is_expected.to be(true) }
       end
 
       context "when the filter is enabled and the proposal has no assigned status" do
         let(:proposal) { create(:proposal, component: filter_component) }
-        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: [accepted_state.id.to_s] } }
+        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(accepted) } }
 
         it { is_expected.to be(true) }
       end
 
+      context "when not_answered is in the allowed list and the proposal has no assigned status" do
+        let(:proposal) { create(:proposal, component: filter_component) }
+        let(:step_settings) { { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: %w(not_answered) } }
+
+        it { is_expected.to be(false) }
+      end
+
       context "when the allowed list contains blank entries" do
         let(:step_settings) do
-          { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: ["", accepted_state.id.to_s] }
+          { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: ["", "accepted"] }
         end
 
         it { is_expected.to be(false) }

--- a/spec/helpers/concerns/decidim/decidim_awesome/admin/settings_helper_override_spec.rb
+++ b/spec/helpers/concerns/decidim/decidim_awesome/admin/settings_helper_override_spec.rb
@@ -72,6 +72,37 @@ module Decidim
             html = helper.send(:render_field_form_method, :awesome_multiselect, form, attribute, :awesome_votes_enabled_states, "scope", { label: "Pick" })
             expect(html).to include('data-controller="awesome-votes-by-status"')
           end
+
+          context "with help text on awesome_votes_enabled_states" do
+            let(:options) { { label: "Pick", help_text: "Save first" } }
+
+            context "when the component is not persisted" do
+              before { helper.instance_variable_set(:@component, Decidim::Component.new) }
+
+              it "renders the help text" do
+                html = helper.send(:render_field_form_method, :awesome_multiselect, form, attribute, :awesome_votes_enabled_states, "scope", options)
+                expect(html).to include("Save first")
+              end
+            end
+
+            context "when the component is persisted" do
+              before { helper.instance_variable_set(:@component, instance_double(Decidim::Component, persisted?: true)) }
+
+              it "hides the help text" do
+                html = helper.send(:render_field_form_method, :awesome_multiselect, form, attribute, :awesome_votes_enabled_states, "scope", options)
+                expect(html).not_to include("Save first")
+              end
+            end
+          end
+
+          context "with help text on other attributes" do
+            before { helper.instance_variable_set(:@component, instance_double(Decidim::Component, persisted?: true)) }
+
+            it "always renders the help text regardless of component state" do
+              html = helper.send(:render_field_form_method, :awesome_multiselect, form, attribute, :picks, "scope", { label: "Pick", help_text: "Always shown" })
+              expect(html).to include("Always shown")
+            end
+          end
         end
 
         context "when the form method is anything else" do

--- a/spec/permissions/concerns/decidim/decidim_awesome/proposals/permissions_override_spec.rb
+++ b/spec/permissions/concerns/decidim/decidim_awesome/proposals/permissions_override_spec.rb
@@ -11,8 +11,6 @@ module Decidim
       let(:user) { create(:user, :confirmed, organization:) }
       let(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
       let(:component) { create(:proposal_component, participatory_space: participatory_process) }
-      let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "accepted") }
-      let(:rejected_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "rejected") }
       let(:proposal) { create(:proposal, component:, state: "accepted") }
       let(:current_settings) { component.current_settings }
       let(:component_settings) { component.settings }
@@ -23,7 +21,7 @@ module Decidim
       let(:step_settings) do
         { votes_enabled: true, awesome_votes_enabled_by_status: true, awesome_votes_enabled_states: }
       end
-      let(:awesome_votes_enabled_states) { [accepted_state.id.to_s] }
+      let(:awesome_votes_enabled_states) { %w(accepted) }
 
       before do
         component.update!(step_settings: { participatory_process.active_step.id => step_settings })
@@ -45,7 +43,7 @@ module Decidim
         end
 
         context "when the proposal status is not in the allowed list" do
-          let(:awesome_votes_enabled_states) { [rejected_state.id.to_s] }
+          let(:awesome_votes_enabled_states) { %w(rejected) }
 
           it_behaves_like "blocks the action"
         end
@@ -54,6 +52,25 @@ module Decidim
           let(:proposal) { create(:proposal, component:) }
 
           it_behaves_like "blocks the action"
+        end
+
+        context "when the proposal has no assigned status and not_answered is allowed" do
+          let(:proposal) { create(:proposal, component:) }
+          let(:awesome_votes_enabled_states) { %w(not_answered) }
+
+          it_behaves_like "allows the action"
+        end
+
+        context "when not_answered is mixed with real tokens" do
+          let(:awesome_votes_enabled_states) { %w(accepted not_answered) }
+
+          it_behaves_like "allows the action"
+
+          context "and the proposal has no assigned status" do
+            let(:proposal) { create(:proposal, component:) }
+
+            it_behaves_like "allows the action"
+          end
         end
 
         context "when the awesome filter is disabled in the component" do
@@ -77,9 +94,16 @@ module Decidim
         end
 
         context "when the proposal status is not in the allowed list" do
-          let(:awesome_votes_enabled_states) { [rejected_state.id.to_s] }
+          let(:awesome_votes_enabled_states) { %w(rejected) }
 
           it_behaves_like "blocks the action"
+        end
+
+        context "when the proposal has no assigned status and not_answered is allowed" do
+          let(:proposal) { create(:proposal, component:) }
+          let(:awesome_votes_enabled_states) { %w(not_answered) }
+
+          it_behaves_like "allows the action"
         end
       end
     end

--- a/spec/services/decidim/decidim_awesome/proposals/votes_by_proposal_status_spec.rb
+++ b/spec/services/decidim/decidim_awesome/proposals/votes_by_proposal_status_spec.rb
@@ -11,12 +11,10 @@ module Decidim
         let(:organization) { create(:organization) }
         let(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
         let(:component) { create(:proposal_component, participatory_space: participatory_process) }
-        let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "accepted") }
-        let(:rejected_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "rejected") }
         let(:proposal) { create(:proposal, component:, state: "accepted") }
 
         let(:settings_class) { Struct.new(:votes_enabled, :awesome_votes_enabled_by_status, :awesome_votes_enabled_states) }
-        let(:settings) { settings_class.new(true, true, [accepted_state.id.to_s]) }
+        let(:settings) { settings_class.new(true, true, %w(accepted)) }
 
         describe "#active?" do
           context "when the global feature flag is disabled" do
@@ -26,13 +24,13 @@ module Decidim
           end
 
           context "when votes are not enabled on the step" do
-            let(:settings) { settings_class.new(false, true, [accepted_state.id.to_s]) }
+            let(:settings) { settings_class.new(false, true, %w(accepted)) }
 
             it { is_expected.not_to be_active }
           end
 
           context "when the per-step checkbox is off" do
-            let(:settings) { settings_class.new(true, false, [accepted_state.id.to_s]) }
+            let(:settings) { settings_class.new(true, false, %w(accepted)) }
 
             it { is_expected.not_to be_active }
           end
@@ -53,6 +51,12 @@ module Decidim
             it { is_expected.to be_active }
           end
 
+          context "when only not_answered is selected" do
+            let(:settings) { settings_class.new(true, true, %w(not_answered)) }
+
+            it { is_expected.to be_active }
+          end
+
           context "when the settings object does not respond to the awesome attributes" do
             let(:settings) { Object.new }
 
@@ -66,7 +70,7 @@ module Decidim
           end
 
           context "when the proposal status is not in the allowed list" do
-            let(:settings) { settings_class.new(true, true, [rejected_state.id.to_s]) }
+            let(:settings) { settings_class.new(true, true, %w(rejected)) }
 
             it { expect(subject.allowed?(proposal)).to be(false) }
           end
@@ -74,37 +78,76 @@ module Decidim
           context "when the proposal has no assigned status" do
             let(:proposal) { create(:proposal, component:) }
 
-            it { expect(subject.allowed?(proposal)).to be(false) }
+            context "and not_answered is in the allowed list" do
+              let(:settings) { settings_class.new(true, true, %w(not_answered)) }
+
+              it { expect(subject.allowed?(proposal)).to be(true) }
+            end
+
+            context "and not_answered is not in the allowed list" do
+              it { expect(subject.allowed?(proposal)).to be(false) }
+            end
+          end
+
+          context "when not_answered is mixed with real tokens" do
+            let(:settings) { settings_class.new(true, true, %w(accepted not_answered)) }
+            let(:not_answered_proposal) { create(:proposal, component:) }
+            let(:rejected_proposal) { create(:proposal, component:, state: "rejected") }
+
+            it "allows the answered proposal in the list" do
+              expect(subject.allowed?(proposal)).to be(true)
+            end
+
+            it "allows the not-answered proposal" do
+              expect(subject.allowed?(not_answered_proposal)).to be(true)
+            end
+
+            it "still blocks proposals whose status is not in the list" do
+              expect(subject.allowed?(rejected_proposal)).to be(false)
+            end
           end
 
           context "when the proposal is nil" do
             it { expect(subject.allowed?(nil)).to be(false) }
           end
 
-          context "when the allowed list mixes blank entries and valid ids" do
-            let(:settings) { settings_class.new(true, true, ["", accepted_state.id.to_s]) }
+          context "when the allowed list mixes blank entries and valid tokens" do
+            let(:settings) { settings_class.new(true, true, ["", "accepted"]) }
 
             it { expect(subject.allowed?(proposal)).to be(true) }
           end
         end
 
-        describe "#allowed_state_ids" do
-          context "with string ids" do
-            let(:settings) { settings_class.new(true, true, %w(1 2 3)) }
+        describe "#allowed_tokens" do
+          context "with several tokens" do
+            let(:settings) { settings_class.new(true, true, %w(accepted rejected not_answered)) }
 
-            it { expect(subject.allowed_state_ids).to eq([1, 2, 3]) }
+            it { expect(subject.allowed_tokens).to eq(%w(accepted rejected not_answered)) }
           end
 
           context "with blank entries" do
-            let(:settings) { settings_class.new(true, true, ["", " ", "5", nil]) }
+            let(:settings) { settings_class.new(true, true, ["", " ", "accepted", nil]) }
 
-            it { expect(subject.allowed_state_ids).to eq([5]) }
+            it { expect(subject.allowed_tokens).to eq(%w(accepted)) }
           end
 
           context "when the attribute is missing" do
             let(:settings) { Object.new }
 
-            it { expect(subject.allowed_state_ids).to eq([]) }
+            it { expect(subject.allowed_tokens).to eq([]) }
+          end
+        end
+
+        describe ".choices_for" do
+          subject { described_class.choices_for(component) }
+
+          it "places not_answered first" do
+            expect(subject.first).to eq([I18n.t("decidim.proposals.answers.not_answered"), "not_answered"])
+          end
+
+          it "lists the real component states with their tokens" do
+            tokens = subject.map(&:last)
+            expect(tokens).to include("accepted", "evaluating", "rejected")
           end
         end
       end

--- a/spec/system/admin/admin_edits_votes_by_proposal_status_settings_spec.rb
+++ b/spec/system/admin/admin_edits_votes_by_proposal_status_settings_spec.rb
@@ -7,8 +7,6 @@ describe "Admin edits votes by proposal status settings", :slow do
   let!(:admin) { create(:user, :admin, :confirmed, organization:) }
   let(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
   let!(:component) { create(:proposal_component, participatory_space: participatory_process) }
-  let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "accepted") }
-  let(:evaluating_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "evaluating") }
 
   before do
     switch_to_host(organization.host)
@@ -48,11 +46,14 @@ describe "Admin edits votes by proposal status settings", :slow do
       end
     end
 
-    it "lists all component statuses as choices when the multiselect is shown" do
+    it "lists all component statuses plus 'Not answered' as choices when the multiselect is shown" do
       within "fieldset.step-settings-#{participatory_process.active_step.id}" do
         check "Restrict voting by proposal status"
 
-        expect(page).to have_select("Allowed statuses for votes", with_options: %w(Accepted Evaluating))
+        expect(page).to have_select(
+          "Allowed statuses for votes",
+          with_options: ["Not answered", "Accepted", "Evaluating", "Rejected"]
+        )
       end
     end
   end
@@ -67,11 +68,28 @@ describe "Admin edits votes by proposal status settings", :slow do
       click_on "Update"
     end
 
-    it "persists the chosen statuses" do
+    it "persists the chosen statuses as tokens" do
       expect(page).to have_admin_callout("successfully")
       step_id = participatory_process.active_step.id.to_s
       expect(component.reload.step_settings[step_id].awesome_votes_enabled_by_status).to be(true)
-      expect(component.step_settings[step_id].awesome_votes_enabled_states).to include(accepted_state.id.to_s)
+      expect(component.step_settings[step_id].awesome_votes_enabled_states).to include("accepted")
+    end
+  end
+
+  context "when saving 'Not answered' as the allowed status" do
+    before do
+      within "fieldset.step-settings-#{participatory_process.active_step.id}" do
+        check "Votes enabled"
+        check "Restrict voting by proposal status"
+        select "Not answered", from: "Allowed statuses for votes"
+      end
+      click_on "Update"
+    end
+
+    it "persists the not_answered token" do
+      expect(page).to have_admin_callout("successfully")
+      step_id = participatory_process.active_step.id.to_s
+      expect(component.reload.step_settings[step_id].awesome_votes_enabled_states).to include("not_answered")
     end
   end
 end

--- a/spec/system/public/votes_by_proposal_status_spec.rb
+++ b/spec/system/public/votes_by_proposal_status_spec.rb
@@ -7,15 +7,13 @@ describe "Votes by proposal status" do
   let(:manifest_name) { "proposals" }
 
   let!(:component) { create(:proposal_component, participatory_space:) }
-  let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "accepted") }
-  let(:rejected_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "rejected") }
 
   let!(:accepted_proposal) { create(:proposal, component:, state: "accepted") }
   let!(:rejected_proposal) { create(:proposal, component:, state: "rejected") }
   let!(:not_answered_proposal) { create(:proposal, component:) }
 
   let(:user) { create(:user, :confirmed, organization:) }
-  let(:not_allowed_text) { "Voting unavailable" }
+  let(:not_allowed_text) { "Not accepted for voting" }
   let(:vote_button_text) { "Vote" }
 
   before do
@@ -70,7 +68,7 @@ describe "Votes by proposal status" do
         {
           votes_enabled: true,
           awesome_votes_enabled_by_status: true,
-          awesome_votes_enabled_states: [accepted_state.id.to_s]
+          awesome_votes_enabled_states: %w(accepted)
         }
       end
 
@@ -102,13 +100,69 @@ describe "Votes by proposal status" do
       end
     end
 
+    context "when only not_answered is allowed" do
+      let(:step_settings) do
+        {
+          votes_enabled: true,
+          awesome_votes_enabled_by_status: true,
+          awesome_votes_enabled_states: %w(not_answered)
+        }
+      end
+
+      it "lets the user vote on proposals without an assigned status" do
+        within vote_area_for(not_answered_proposal) do
+          expect(page).to have_button(vote_button_text)
+          expect(page).to have_no_content(not_allowed_text)
+        end
+      end
+
+      it "blocks proposals with an assigned status" do
+        within vote_area_for(accepted_proposal) do
+          expect(page).to have_content(not_allowed_text)
+          expect(page).to have_no_button(vote_button_text)
+        end
+        within vote_area_for(rejected_proposal) do
+          expect(page).to have_content(not_allowed_text)
+          expect(page).to have_no_button(vote_button_text)
+        end
+      end
+    end
+
+    context "when not_answered is mixed with a real status" do
+      let(:step_settings) do
+        {
+          votes_enabled: true,
+          awesome_votes_enabled_by_status: true,
+          awesome_votes_enabled_states: %w(accepted not_answered)
+        }
+      end
+
+      it "allows voting on both the accepted and the not-answered proposal" do
+        within vote_area_for(accepted_proposal) do
+          expect(page).to have_button(vote_button_text)
+          expect(page).to have_no_content(not_allowed_text)
+        end
+        within vote_area_for(not_answered_proposal) do
+          expect(page).to have_button(vote_button_text)
+          expect(page).to have_no_content(not_allowed_text)
+        end
+      end
+
+      it "still blocks proposals whose status is not in the list" do
+        within vote_area_for(rejected_proposal) do
+          expect(page).to have_content(not_allowed_text)
+          expect(page).to have_no_button(vote_button_text)
+        end
+      end
+    end
+
     context "when votes are blocked at the step level" do
       let(:step_settings) do
         {
           votes_enabled: true,
           votes_blocked: true,
           awesome_votes_enabled_by_status: true,
-          awesome_votes_enabled_states: [accepted_state.id.to_s]
+          awesome_votes_enabled_states: %w(accepted)
         }
       end
 

--- a/spec/system/public/votes_by_proposal_status_spec.rb
+++ b/spec/system/public/votes_by_proposal_status_spec.rb
@@ -13,7 +13,7 @@ describe "Votes by proposal status" do
   let!(:not_answered_proposal) { create(:proposal, component:) }
 
   let(:user) { create(:user, :confirmed, organization:) }
-  let(:not_allowed_text) { "Not accepted for voting" }
+  let(:not_allowed_text) { "Voting unavailable" }
   let(:vote_button_text) { "Vote" }
 
   before do

--- a/spec/system/public/votes_by_proposal_status_with_voting_cards_spec.rb
+++ b/spec/system/public/votes_by_proposal_status_with_voting_cards_spec.rb
@@ -13,18 +13,18 @@ describe "Votes by proposal status with voting cards" do
       settings: { awesome_voting_manifest: "voting_cards" }
     )
   end
-  let(:accepted_state) { Decidim::Proposals::ProposalState.find_by(component:, token: "accepted") }
   let!(:accepted_proposal) { create(:proposal, component:, state: "accepted") }
   let!(:rejected_proposal) { create(:proposal, component:, state: "rejected") }
+  let!(:not_answered_proposal) { create(:proposal, component:) }
 
   let(:user) { create(:user, :confirmed, organization:) }
-  let(:not_allowed_text) { "Voting unavailable" }
+  let(:not_allowed_text) { "Not accepted for voting" }
 
   let(:step_settings) do
     {
       votes_enabled: true,
       awesome_votes_enabled_by_status: true,
-      awesome_votes_enabled_states: [accepted_state.id.to_s]
+      awesome_votes_enabled_states: %w(accepted)
     }
   end
 
@@ -58,6 +58,29 @@ describe "Votes by proposal status with voting cards" do
         expect(page).to have_content("Green")
       end
     end
+
+    it "shows the blocked message for proposals without an assigned status" do
+      within vote_area_for(not_answered_proposal) do
+        expect(page).to have_content(not_allowed_text)
+        expect(page).to have_no_content("Green")
+      end
+    end
+  end
+
+  shared_examples "voting cards status filter with not_answered allowed" do
+    it "shows voting cards UI for proposals without an assigned status" do
+      within vote_area_for(not_answered_proposal) do
+        expect(page).to have_no_content(not_allowed_text)
+        expect(page).to have_content("Green")
+      end
+    end
+
+    it "blocks proposals whose status is not in the list" do
+      within vote_area_for(rejected_proposal) do
+        expect(page).to have_content(not_allowed_text)
+        expect(page).to have_no_content("Green")
+      end
+    end
   end
 
   context "when in list view" do
@@ -68,5 +91,17 @@ describe "Votes by proposal status with voting cards" do
     before { switch_to_grid_mode }
 
     it_behaves_like "voting cards status filter"
+  end
+
+  context "when not_answered is allowed" do
+    let(:step_settings) do
+      {
+        votes_enabled: true,
+        awesome_votes_enabled_by_status: true,
+        awesome_votes_enabled_states: %w(not_answered)
+      }
+    end
+
+    it_behaves_like "voting cards status filter with not_answered allowed"
   end
 end

--- a/spec/system/public/votes_by_proposal_status_with_voting_cards_spec.rb
+++ b/spec/system/public/votes_by_proposal_status_with_voting_cards_spec.rb
@@ -18,7 +18,7 @@ describe "Votes by proposal status with voting cards" do
   let!(:not_answered_proposal) { create(:proposal, component:) }
 
   let(:user) { create(:user, :confirmed, organization:) }
-  let(:not_allowed_text) { "Not accepted for voting" }
+  let(:not_allowed_text) { "Voting unavailable" }
 
   let(:step_settings) do
     {


### PR DESCRIPTION
#### :tophat: What? Why?
Adds "Not answered" as a selectable status in the votes-by-status restriction.

#### :pushpin: Related Issues
- Extends #583 

#### Testing
- Pick "Not answered" in the statuses multiselect → only proposals without an admin answer can be voted
- Mix "Accepted" + "Not answered" → both vote; rejected ones blocked