### PR TITLE
Fix: process group form override in 0.31

### DIFF
--- a/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
+++ b/app/overrides/decidim/participatory_processes/admin/participatory_process_groups/_form/add_visibility_callout.html.erb.deface
@@ -1,3 +1,4 @@
 <!-- insert_bottom "div#panel-visibility" -->
+<% participatory_space = params[:id].nil? ? nil : participatory_process_group %>
 
-<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_process_group %>
+<%= render "decidim/decidim_awesome/admin/shared/visibility_notice", participatory_space: participatory_space %>


### PR DESCRIPTION
🎩 Description
This PR is a backport of https://github.com/OpenSourcePolitics/decidim-module-decidim_awesome/pull/2, to solve the same problem in 0.31.

Testing
As an admin, go to processes > process groups
Click on 'New process group'
See that you can access the new view without error

📌 Related Issues
Link your PR to an issue

issue https://github.com/decidim-ice/decidim-module-decidim_awesome/issues/587