### PR TITLE
Fix: allow adding/editing cookie items on default categories

### DIFF
--- a/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
@@ -51,7 +51,7 @@ module Decidim
         attr_reader :forms, :category_slug
 
         def category
-          @category ||= @config.value[category_slug]
+          @category ||= @config.value&.[](category_slug)
         end
 
         def existing_items

--- a/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
@@ -11,7 +11,8 @@ module Decidim
         def initialize(forms, category_slug)
           @forms = forms
           @category_slug = category_slug
-          @config = AwesomeConfig.find_or_initialize_by(organization: forms.first.current_organization, var: :cookie_management)
+          @organization = forms.first.current_organization
+          @config = AwesomeConfig.find_or_initialize_by(organization: @organization, var: :cookie_management)
         end
 
         # Executes the command. Broadcasts these events:
@@ -31,7 +32,8 @@ module Decidim
 
             UpdateCookieItem.call(form_with_context, category_slug) do
               on(:ok) do
-                existing_items.merge!(form.name => form.to_params)
+                category["items"] ||= {}
+                category["items"].merge!(form.name => form.to_params)
               end
               on(:invalid) do |error_message|
                 errors << "#{form.name}: #{error_message.presence || form.errors.full_messages.join(", ")}"
@@ -50,12 +52,12 @@ module Decidim
 
         attr_reader :forms, :category_slug
 
-        def category
-          @category ||= @config.value&.[](category_slug)
+        def store
+          @store ||= CookieManagementStore.new(@organization, @config.value || {})
         end
 
-        def existing_items
-          @existing_items ||= category&.dig("items") || {}
+        def category
+          @category ||= store.categories[category_slug]
         end
       end
     end

--- a/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_cookie_item_preset.rb
@@ -11,7 +11,7 @@ module Decidim
         def initialize(forms, category_slug)
           @forms = forms
           @category_slug = category_slug
-          @config = AwesomeConfig.find_by(organization: forms.first.current_organization, var: :cookie_management)
+          @config = AwesomeConfig.find_or_initialize_by(organization: forms.first.current_organization, var: :cookie_management)
         end
 
         # Executes the command. Broadcasts these events:
@@ -55,7 +55,7 @@ module Decidim
         end
 
         def existing_items
-          @existing_items ||= category["items"] || {}
+          @existing_items ||= category&.dig("items") || {}
         end
       end
     end

--- a/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
@@ -28,6 +28,7 @@ module Decidim
 
           config.value ||= {}
           return broadcast(:invalid) unless store.categories[category_slug]
+
           config.value[category_slug] ||= { "slug" => category_slug, "items" => {} }
 
           config.value[category_slug]["items"] ||= {}

--- a/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
@@ -44,6 +44,8 @@ module Decidim
           broadcast(:invalid, e.message)
         end
 
+        private
+
         def store
           @store ||= CookieManagementStore.new(form.current_organization, config.value)
         end

--- a/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
@@ -12,7 +12,7 @@ module Decidim
         def initialize(form, category_slug)
           @form = form
           @category_slug = category_slug
-          @config = AwesomeConfig.find_by(organization: form.current_organization, var: :cookie_management)
+          @config = AwesomeConfig.find_or_initialize_by(organization: form.current_organization, var: :cookie_management)
         end
 
         attr_reader :form, :category_slug, :config
@@ -25,7 +25,8 @@ module Decidim
         # Returns nothing.
         def call
           return broadcast(:invalid) if form.invalid?
-          return broadcast(:invalid) unless config&.value&.[](category_slug)
+          config.value ||= {}
+          config.value[category_slug] ||= { "slug" => category_slug, "items" => {} }
 
           config.value[category_slug]["items"] ||= {}
           # Handle slug change by deleting old key

--- a/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
@@ -25,6 +25,7 @@ module Decidim
         # Returns nothing.
         def call
           return broadcast(:invalid) if form.invalid?
+
           config.value ||= {}
           config.value[category_slug] ||= { "slug" => category_slug, "items" => {} }
 

--- a/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_cookie_item.rb
@@ -27,6 +27,7 @@ module Decidim
           return broadcast(:invalid) if form.invalid?
 
           config.value ||= {}
+          return broadcast(:invalid) unless store.categories[category_slug]
           config.value[category_slug] ||= { "slug" => category_slug, "items" => {} }
 
           config.value[category_slug]["items"] ||= {}
@@ -40,6 +41,10 @@ module Decidim
           broadcast(:invalid, e.record.errors.full_messages.join(", "))
         rescue StandardError => e
           broadcast(:invalid, e.message)
+        end
+
+        def store
+          @store ||= CookieManagementStore.new(form.current_organization, config.value)
         end
       end
     end

--- a/spec/commands/admin/update_cookie_item_spec.rb
+++ b/spec/commands/admin/update_cookie_item_spec.rb
@@ -98,6 +98,23 @@ module Decidim::DecidimAwesome
         end
       end
 
+      context "when category exists only as a decidim default (not in DB config)" do
+        let(:category_slug) { "essential" }
+        let(:category) { nil }
+
+        before do
+          allow(Decidim).to receive(:consent_categories).and_return([
+            { slug: :essential, mandatory: false, items: [] }
+          ])
+        end
+
+        it "broadcasts :ok and initializes the category in DB" do
+          expect { subject.call }.to broadcast(:ok)
+          expect(cookie_management_config.reload.value[category_slug]).to be_present
+          expect(cookie_management_config.value[category_slug]["items"]["decidim_analytics_updated"]).to be_present
+        end
+      end
+
       context "when slug already exists" do
         let(:existing_categories) do
           {

--- a/spec/commands/admin/update_cookie_item_spec.rb
+++ b/spec/commands/admin/update_cookie_item_spec.rb
@@ -103,9 +103,7 @@ module Decidim::DecidimAwesome
         let(:category) { nil }
 
         before do
-          allow(Decidim).to receive(:consent_categories).and_return([
-            { slug: :essential, mandatory: false, items: [] }
-          ])
+          allow(Decidim).to receive(:consent_categories).and_return([{ slug: :essential, mandatory: false, items: [] }])
         end
 
         it "broadcasts :ok and initializes the category in DB" do


### PR DESCRIPTION
🎩 What? Why?
Until now, if you tried to add items to a default category or use the predefined item presets on those categories, the operation would silently fail with no clear error message. This happened because the system was only looking for categories in the database, but default categories are not stored there until someone modifies them for the first time.

With this fix, when you add an item to a default category, the system automatically initializes it in the database and continues without errors.

📌 Related Issues
Link your PR to an issue

Related to #?
Fixes #589 

♥️ Thank you!