### PR TITLE
Allow to edit the authorization name/description

### DIFF
--- a/app/commands/decidim/decidim_awesome/admin/update_awesome_authorization_properties.rb
+++ b/app/commands/decidim/decidim_awesome/admin/update_awesome_authorization_properties.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DecidimAwesome
+    module Admin
+      class UpdateAwesomeAuthorizationProperties < Command
+        # Public: Initializes the command.
+        #
+        # form - A AwesomeAuthorizationPropertiesForm form
+        def initialize(form)
+          @form = form
+        end
+
+        attr_reader :form
+
+        def call
+          return broadcast(:invalid, form.errors.full_messages.join("; ")) if form.invalid?
+
+          config = Decidim::DecidimAwesome::AwesomeConfig.find_or_initialize_by(var: :awesome_authorization_handler, organization: form.current_organization)
+
+          if form.empty?
+            config.destroy! if config.persisted?
+          else
+            config.value = {
+              name: form.name,
+              explanation: form.explanation
+            }
+            config.save!
+          end
+
+          broadcast(:ok)
+        rescue StandardError => e
+          broadcast(:invalid, e.message)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/decidim_awesome/admin/awesome_authorization_properties_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/awesome_authorization_properties_controller.rb
@@ -10,9 +10,34 @@ module Decidim
           enforce_permission_to :edit_config, :awesome_authorization_handler
         end
 
-        def index; end
+        def index
+          @form = form(AwesomeAuthorizationPropertiesForm).from_params(current_properties)
+        end
+
+        def create
+          @form = form(AwesomeAuthorizationPropertiesForm).from_params(params)
+
+          UpdateAwesomeAuthorizationProperties.call(@form) do
+            on(:ok) do
+              flash[:notice] = I18n.t("awesome_authorization_properties.create.success", scope: "decidim.decidim_awesome.admin")
+              redirect_to decidim_admin_decidim_awesome.awesome_authorizations_path
+            end
+
+            on(:invalid) do |error|
+              flash.now[:alert] = I18n.t("awesome_authorization_properties.create.error", error:, scope: "decidim.decidim_awesome.admin")
+              render :index
+            end
+          end
+        end
 
         private
+
+        def current_properties
+          value = AwesomeConfig.find_by(var: :awesome_authorization_handler, organization: current_organization)&.value
+          return {} unless value.is_a?(Hash)
+
+          value.slice("name", "explanation")
+        end
       end
     end
   end

--- a/app/forms/decidim/decidim_awesome/admin/awesome_authorization_properties_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/awesome_authorization_properties_form.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DecidimAwesome
+    module Admin
+      class AwesomeAuthorizationPropertiesForm < Decidim::Form
+        include Decidim::TranslatableAttributes
+        translatable_attribute :name, String
+        translatable_attribute :explanation, String
+
+        validate :name_max_length
+        validate :explanation_max_length
+
+        # checks if values are empty for the organization's locale, if so, it will be considered empty and the config var will be deleted
+        def empty?
+          locale = current_organization.default_locale.to_s
+
+          name[locale].blank? && explanation[locale].blank?
+        end
+
+        private
+
+        def name_max_length
+          return unless translated_too_long?(name, 255)
+
+          errors.add(:name, :too_long, count: 255)
+        end
+
+        def explanation_max_length
+          return unless translated_too_long?(explanation, 1000)
+
+          errors.add(:explanation, :too_long, count: 1000)
+        end
+
+        def translated_too_long?(value, max_length)
+          value.to_h.values.any? { |text| text.to_s.length > max_length }
+        end
+      end
+    end
+  end
+end

--- a/app/views/decidim/decidim_awesome/admin/awesome_authorization_properties/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/awesome_authorization_properties/index.html.erb
@@ -1,1 +1,31 @@
-todo #AV-3
+<div class="item_show__header">
+  <h2 class="item_show__header-title">
+    <%= t(".title") %>
+    <%= link_to t(".cancel"), decidim_admin_decidim_awesome.awesome_authorizations_path, class: "button button__sm button__secondary" %>
+  </h2>
+</div>
+
+<div class="item__edit item__edit-1col">
+  <div class="item__edit-form">
+    <%= decidim_form_for(@form, url: decidim_admin_decidim_awesome.awesome_authorization_properties_path, html: { class: "form-defaults form awesome_authorization_properties" }) do |f| %>
+      <div class="form__wrapper">
+        <div class="card pt-4">
+          <div class="card-section">
+            <div class="row column">
+              <%= f.translated :text_field, :name, label: t(".name"), help_text: t(".name_help"), placeholder: t("decidim.decidim_awesome.awesome_authorization_handler.name") %>
+            </div>
+            <div class="row column">
+              <%= f.translated :text_area, :explanation, label: t(".description"), help_text: t(".description_help"), placeholder: t("decidim.decidim_awesome.awesome_authorization_handler.explanation"), data: { controller: "character-counter" } %>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= f.submit t(".save"), class: "button button__sm button__secondary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/decidim/decidim_awesome/admin/awesome_authorizations/_awesome_authorization_card.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/awesome_authorizations/_awesome_authorization_card.html.erb
@@ -2,10 +2,10 @@
 <%= icon "checkbox-circle-line", class: "verification__icon is-granted" %>
   <div class="verification__text">
     <h2 class="h5 text-secondary">
-      <%= t("decidim.decidim_awesome.awesome_authorization_handler.name") %>
+      <%= t("decidim.authorization_handlers.awesome_authorization_handler.name") %>
     </h2>
     <span>
-      <%= t("decidim.decidim_awesome.awesome_authorization_handler.explanation") %>
+      <%= t("decidim.authorization_handlers.awesome_authorization_handler.explanation") %>
     </span>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,7 +177,7 @@ en:
             awesome_voting_manifest: Support type
             awesome_voting_manifest_help_html: <span class="text-alert">Be aware that
               changing this setting in the middle of a votation period can result
-              in innacurate or unexpected results.</span><br>Note also that this setting
+              in inaccurate or unexpected results.</span><br>Note also that this setting
               can only be edited if the component has no supports yet.
             awesome_voting_manifest_options:
               default: Simple vote (default)
@@ -291,6 +291,20 @@ en:
               user''s current authorization status.'
           user_authorized: "%{user} successfully authorized with %{name}"
           user_not_authorized: "%{user} could not be authorized with %{name}"
+        awesome_authorization_properties:
+          create:
+            error: Error updating authorization properties! %{error}
+            success: Authorization properties updated successfully
+          index:
+            cancel: Cancel
+            description: Authorization description
+            description_help: This text is shown below the authorization title in
+              the verification card when users are still not verified. You can use
+              it to explain why this authorization is required.
+            name: Authorization name
+            name_help: This title is shown in the verification card.
+            save: Save
+            title: Edit authorization properties
         awesome_authorizations:
           index:
             authorization_groups: Authorization groups

--- a/config/locales/zz_dynamic_locales.rb
+++ b/config/locales/zz_dynamic_locales.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
-handler = {
-  decidim: {
-    authorization_handlers: {
-      awesome_authorization_handler: {
-        name: lambda { |_key, options|
-          config = Thread.current[:awesome_authorization_handler]
-          options.delete(:scope)
-          return I18n.t("decidim.decidim_awesome.awesome_authorization_handler.name", **options) unless config
+Decidim.available_locales.index_with do |locale|
+  {
+    decidim: {
+      authorization_handlers: {
+        awesome_authorization_handler: {
+          name: lambda { |_key, options|
+            config = Thread.current[:awesome_authorization_handler]
+            options.delete(:scope)
+            return I18n.t("decidim.decidim_awesome.awesome_authorization_handler.name", **options) unless config.is_a?(Hash)
 
-          config&.dig("name") || I18n.t("decidim.decidim_awesome.awesome_authorization_handler.name", **options)
-        },
-        explanation: lambda { |_key, options|
-          config = Thread.current[:awesome_authorization_handler]
-          options.delete(:scope)
-          return I18n.t("decidim.decidim_awesome.awesome_authorization_handler.explanation", **options) unless config
+            config.dig("name", locale).presence || I18n.t("decidim.decidim_awesome.awesome_authorization_handler.name", **options)
+          },
+          explanation: lambda { |_key, options|
+            config = Thread.current[:awesome_authorization_handler]
+            options.delete(:scope)
+            return I18n.t("decidim.decidim_awesome.awesome_authorization_handler.explanation", **options) unless config.is_a?(Hash)
 
-          config&.dig("explanation") || I18n.t("decidim.decidim_awesome.awesome_authorization_handler.explanation", **options)
+            config.dig("explanation", locale).presence || I18n.t("decidim.decidim_awesome.awesome_authorization_handler.explanation", **options)
+          }
         }
       }
     }
   }
-}
-
-Decidim.available_locales.index_with do |_locale|
-  handler
 end

--- a/spec/commands/admin/update_awesome_authorization_properties_spec.rb
+++ b/spec/commands/admin/update_awesome_authorization_properties_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::DecidimAwesome
+  module Admin
+    describe UpdateAwesomeAuthorizationProperties do
+      subject { described_class.new(form) }
+
+      let(:organization) { create(:organization) }
+      let(:context) do
+        {
+          current_user: create(:user, organization:),
+          current_organization: organization
+        }
+      end
+      let(:locale) { organization.default_locale.to_s }
+      let(:params) do
+        {
+          name: { locale => "Organization groups" },
+          explanation: { locale => "Custom authorization description" }
+        }
+      end
+      let(:form) do
+        AwesomeAuthorizationPropertiesForm.from_params(params).with_context(context)
+      end
+
+      context "when valid" do
+        it "broadcasts :ok and stores properties" do
+          expect { subject.call }.to broadcast(:ok)
+
+          expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)&.value).to include(
+            "name" => include(locale => "Organization groups"),
+            "explanation" => include(locale => "Custom authorization description")
+          )
+        end
+      end
+
+      context "when empty values" do
+        let(:params) do
+          {
+            name: { locale => "" },
+            explanation: { locale => "" }
+          }
+        end
+
+        let!(:config) do
+          create(:awesome_config, organization:, var: :awesome_authorization_handler, value: { "name" => { locale => "Existing" } })
+        end
+
+        it "broadcasts :ok and removes existing config" do
+          expect { subject.call }.to broadcast(:ok)
+          expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)).to be_nil
+        end
+      end
+
+      context "when invalid" do
+        let(:params) do
+          {
+            name: { locale => "Organization groups" },
+            explanation: { locale => "a" * 1001 }
+          }
+        end
+
+        it "broadcasts :invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+          expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/awesome_authorization_properties_controller_spec.rb
+++ b/spec/controllers/admin/awesome_authorization_properties_controller_spec.rb
@@ -42,6 +42,75 @@ module Decidim
             end
           end
         end
+
+        describe "POST #create" do
+          let(:locale) { organization.default_locale.to_s }
+          let(:params) do
+            {
+              awesome_authorization_properties: {
+                "name_#{locale}" => "Organization groups",
+                "explanation_#{locale}" => "Custom authorization description"
+              }
+            }
+          end
+
+          context "with valid params" do
+            it "redirects to awesome authorizations page" do
+              post :create, params: params
+
+              expect(response).to have_http_status(:found)
+              expect(response).to redirect_to(awesome_authorizations_path)
+            end
+
+            it "stores the properties in awesome config" do
+              post :create, params: params
+
+              expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)&.value).to include(
+                {
+                  "name" => include(locale => "Organization groups"),
+                  "explanation" => include(locale => "Custom authorization description")
+                }
+              )
+            end
+
+            it "removes blank fields from the stored config" do
+              create(:awesome_config, organization:, var: :awesome_authorization_handler, value: { "name" => { locale => "Existing" } })
+
+              post :create, params: {
+                awesome_authorization_properties: {
+                  "name_#{locale}" => "",
+                  "explanation_#{locale}" => ""
+                }
+              }
+
+              expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)).to be_nil
+            end
+          end
+
+          context "with invalid params" do
+            let(:params) do
+              {
+                awesome_authorization_properties: {
+                  "name_#{locale}" => "Organization groups",
+                  "explanation_#{locale}" => "a" * 1001
+                }
+              }
+            end
+
+            it "renders index with errors" do
+              post :create, params: params
+
+              expect(response).to have_http_status(:ok)
+              expect(response).to render_template(:index)
+            end
+
+            it "does not store the config" do
+              post :create, params: params
+
+              expect(AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)).to be_nil
+            end
+          end
+        end
       end
     end
   end

--- a/spec/system/admin/admin_manages_awesome_authorizations_spec.rb
+++ b/spec/system/admin/admin_manages_awesome_authorizations_spec.rb
@@ -28,6 +28,24 @@ describe "Admin manages awesome authorizations" do
       it "shows the page title" do
         expect(page).to have_content("Awesome authorizations")
       end
+
+      it "allows updating authorization properties" do
+        locale = organization.default_locale
+
+        visit decidim_admin_decidim_awesome.awesome_authorization_properties_path
+
+        fill_in "awesome_authorization_properties_name_#{locale}", with: "Organization groups"
+        fill_in "awesome_authorization_properties_explanation_#{locale}", with: "Custom description for this authorization"
+        click_on "Save"
+
+        expect(page).to have_content("updated successfully")
+        expect(Decidim::DecidimAwesome::AwesomeConfig.find_by(organization:, var: :awesome_authorization_handler)&.value).to include(
+          {
+            "name" => include(locale.to_s => "Organization groups"),
+            "explanation" => include(locale.to_s => "Custom description for this authorization")
+          }
+        )
+      end
     end
 
     context "when authorization is not available in organization" do


### PR DESCRIPTION
implements #603 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin page to edit authorization handler details, including localized name and explanation fields.
  * Saved changes now persist per organization and support clearing the stored values by leaving the form blank.

* **Bug Fixes**
  * Improved validation and error handling for invalid submissions.
  * Fixed translation lookups for the authorization card and corrected a typo in an English message.

* **Tests**
  * Added coverage for form handling, controller behavior, and end-to-end admin editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->