### PR TITLE
Add CRUD operatios for group members

### DIFF
--- a/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
@@ -22,7 +22,7 @@ module Decidim
 
           previous_members_count = authorization_group.members.count
           authorization_group.members.insert_all( # rubocop:disable Rails/SkipsModelValidations
-            form.data.map { |email| { email: email } },
+            form.data.map { |email| { email: email.strip.downcase } },
             unique_by: :index_auth_members_group_email
           )
           created_count = authorization_group.members.count - previous_members_count

--- a/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DecidimAwesome
+    module Admin
+      class CreateAwesomeAuthorizationMembers < Command
+        # Public: Initializes the command.
+        #
+        # form - The form object containing the authorization group and emails.
+        def initialize(form)
+          @form = form
+        end
+
+        # Executes the command. Broadcasts these events:
+        #
+        # - :ok when all members were added or already existed.
+        # - :invalid if some members could not be created.
+        #
+        # Returns nothing.
+        def call
+          authorization_group.members.destroy_all if form.remove_previous_members
+
+          previous_members_count = authorization_group.members.count
+          authorization_group.members.insert_all(form.data.map { |email| { email: email } }) # rubocop:disable Rails/SkipsModelValidations
+          created_count = authorization_group.members.count - previous_members_count
+
+          if created_count.zero? && form.remove_previous_members.blank?
+            return broadcast(:invalid,
+                             I18n.t("decidim.decidim_awesome.admin.awesome_authorization_users.update.empty"))
+          end
+
+          broadcast(:ok, created_count)
+        rescue StandardError => e
+          broadcast(:invalid, e.message)
+        end
+
+        private
+
+        attr_reader :form
+      end
+    end
+  end
+end

--- a/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
@@ -21,8 +21,8 @@ module Decidim
           authorization_group.members.destroy_all if form.remove_previous_members
 
           previous_members_count = authorization_group.members.count
-          authorization_group.members.insert_all(
-            form.data.map { |email| { email: email } }, # rubocop:disable Rails/SkipsModelValidations
+          authorization_group.members.insert_all( # rubocop:disable Rails/SkipsModelValidations
+            form.data.map { |email| { email: email } },
             unique_by: :index_auth_members_group_email
           )
           created_count = authorization_group.members.count - previous_members_count

--- a/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
+++ b/app/commands/decidim/decidim_awesome/admin/create_awesome_authorization_members.rb
@@ -21,7 +21,10 @@ module Decidim
           authorization_group.members.destroy_all if form.remove_previous_members
 
           previous_members_count = authorization_group.members.count
-          authorization_group.members.insert_all(form.data.map { |email| { email: email } }) # rubocop:disable Rails/SkipsModelValidations
+          authorization_group.members.insert_all(
+            form.data.map { |email| { email: email } }, # rubocop:disable Rails/SkipsModelValidations
+            unique_by: :index_auth_members_group_email
+          )
           created_count = authorization_group.members.count - previous_members_count
 
           if created_count.zero? && form.remove_previous_members.blank?
@@ -37,6 +40,10 @@ module Decidim
         private
 
         attr_reader :form
+
+        def authorization_group
+          form.authorization_group
+        end
       end
     end
   end

--- a/app/controllers/decidim/decidim_awesome/admin/awesome_authorization_users_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/awesome_authorization_users_controller.rb
@@ -1,18 +1,61 @@
 # frozen_string_literal: true
 
+require "csv"
+
 module Decidim
   module DecidimAwesome
     module Admin
       class AwesomeAuthorizationUsersController < DecidimAwesome::Admin::ApplicationController
+        include Decidim::Admin::Filterable
         helper ConfigConstraintsHelpers
 
         before_action do
           enforce_permission_to :edit_config, :awesome_authorization_handler
         end
 
+        helper_method :authorization_group, :authorization_members
+
         def index; end
 
+        def new
+          @form = form(AwesomeAuthorizationMembersForm).instance
+        end
+
+        def create
+          @form = form(AwesomeAuthorizationMembersForm).from_params(params, authorization_group:)
+
+          CreateAwesomeAuthorizationMembers.call(@form) do
+            on(:ok) do |created_count|
+              flash[:notice] = I18n.t("decidim.decidim_awesome.admin.awesome_authorization_users.create.success", count: created_count)
+              redirect_to decidim_admin_decidim_awesome.awesome_authorization_users_path(authorization_group)
+            end
+
+            on(:invalid) do |error|
+              flash.now[:alert] = I18n.t("decidim.decidim_awesome.admin.awesome_authorization_users.create.error", error: error)
+              render :index
+            end
+          end
+        end
+
+        def destroy
+          authorization_group.members.find(params[:id]).destroy!
+          flash[:notice] = I18n.t("decidim.decidim_awesome.admin.awesome_authorization_users.destroy.success")
+          redirect_to decidim_admin_decidim_awesome.awesome_authorization_users_path(authorization_group)
+        end
+
         private
+
+        def base_query
+          authorization_group.members.order(:email)
+        end
+
+        def authorization_group
+          @authorization_group ||= current_organization.awesome_authorization_groups.find(params[:awesome_authorization_id])
+        end
+
+        def authorization_members
+          @authorization_members ||= paginate(base_query)
+        end
       end
     end
   end

--- a/app/forms/decidim/decidim_awesome/admin/awesome_authorization_members_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/awesome_authorization_members_form.rb
@@ -26,7 +26,7 @@ module Decidim
             end
             yield text
           else
-            yield emails
+            yield emails.to_s
           end
         end
 
@@ -37,7 +37,7 @@ module Decidim
         private
 
         def extract_emails_from_text(text)
-          text.split(/[\s,;]+/).map(&:strip).grep(URI::MailTo::EMAIL_REGEXP)
+          text.split(/[\s,;]+/).map { |email| email.strip.downcase }.grep(URI::MailTo::EMAIL_REGEXP)
         end
       end
     end

--- a/app/forms/decidim/decidim_awesome/admin/awesome_authorization_members_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/awesome_authorization_members_form.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Decidim
+  module DecidimAwesome
+    module Admin
+      class AwesomeAuthorizationMembersForm < Decidim::Form
+        include Decidim::HasUploadValidations
+        include Decidim::ProcessesFileLocally
+
+        attribute :remove_previous_members, Boolean
+        attribute :emails, String
+        attribute :file, Decidim::Attributes::Blob
+
+        validates :file, file_content_type: { allow: ["text/csv"] }
+
+        def data
+          @data ||= process_data do |text|
+            extract_emails_from_text(text)
+          end
+        end
+
+        def process_data
+          if file.present?
+            text = process_file_locally(file) do |file_path|
+              File.read(file_path)
+            end
+            yield text
+          else
+            yield emails
+          end
+        end
+
+        def authorization_group
+          context[:authorization_group]
+        end
+
+        private
+
+        def extract_emails_from_text(text)
+          text.split(/[\s,;]+/).map(&:strip).grep(URI::MailTo::EMAIL_REGEXP)
+        end
+      end
+    end
+  end
+end

--- a/app/models/decidim/decidim_awesome/authorization_member.rb
+++ b/app/models/decidim/decidim_awesome/authorization_member.rb
@@ -12,6 +12,24 @@ module Decidim
 
       before_validation :normalize_email
 
+      delegate :organization, to: :authorization_group
+
+      def user
+        @user ||= organization.users.find_by(email: email)
+      end
+
+      def authorization
+        @authorization ||= Decidim::Authorization.find_by(user:)
+      end
+
+      def self.ransackable_associations(_auth_object = nil)
+        []
+      end
+
+      def self.ransackable_attributes(_auth_object = nil)
+        %w(email)
+      end
+
       private
 
       def normalize_email

--- a/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/index.html.erb
@@ -6,6 +6,12 @@
   </h1>
 </div>
 
+<% unless authorization_group.synced? %>
+  <div class="callout warning">
+    <%= t(".not_synced") %>
+  </div>
+<% end %>
+
 <div class="table-stacked">
   <% if authorization_members.any? %>
     <table class="table-list">

--- a/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/index.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/index.html.erb
@@ -1,1 +1,39 @@
-todo #AV-7
+<div class="item_show__header">
+  <h1 class="item_show__header-title">
+    <%= t(".title", group: translated_attribute(authorization_group.name)) %>
+
+    <%= link_to t(".new"), [:new, :awesome_authorization_user], class: "button button__sm button__secondary" %>
+  </h1>
+</div>
+
+<div class="table-stacked">
+  <% if authorization_members.any? %>
+    <table class="table-list">
+      <thead>
+        <tr>
+          <th><%= t(".email") %></th>
+          <th><%= t(".user") %></th>
+          <th><%= t(".authorized_user") %></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% authorization_members.each do |member| %>
+          <tr>
+            <td><%= member.email %></td>
+            <td><%= link_to member.user.name, decidim.profile_path(member.user.nickname) if member.user %></td>
+            <td><%= link_to member.authorization.user.name, decidim.profile_path(member.authorization.user.nickname) if member.authorization&.user %></td>
+            <td class="table-list__actions">
+              <%= icon_link_to "delete-bin-line", decidim_admin_decidim_awesome.awesome_authorization_user_path(authorization_group, member), t(".remove"), method: :delete, class: "action-icon--delete", data: { confirm: t(".confirm_remove") } %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="callout info">
+      <%= t(".no_members") %>
+    </div>
+  <% end %>
+</div>
+<%= decidim_paginate authorization_members %>

--- a/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/new.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/awesome_authorization_users/new.html.erb
@@ -1,0 +1,39 @@
+<div class="item_show__header">
+  <h2 class="item_show__header-title">
+    <%= t ".title", group: translated_attribute(authorization_group.name) %>
+  </h2>
+</div>
+
+<div class="item__edit item__edit-1col">
+  <div class="item__edit-form">
+    <%= decidim_form_for(@form, url: awesome_authorization_users_path, multipart: true, html: { class: "form-defaults form" }) do |f| %>
+
+      <div class="form__wrapper">
+        <div class="card pt-4">
+          <div class="card-section">
+            <div class="row column">
+              <%= f.check_box :remove_previous_members, label: t(".remove_previous_members", count: authorization_members.count) %>
+            </div>
+            <div class="row column">
+              <%= f.text_area :emails, help_text: t(".emails_help") %>
+            </div>
+            <div class="row column">
+              <h3 class="h3"><%= t(".or") %></h3>
+            </div>
+            <div class="row column">
+              <div class="font-semibold">
+                <%= f.upload :file, help_i18n_scope: "decidim.admin.forms.file_help.import_csv", button_class: "button button__sm button__transparent-secondary" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= f.submit t(".create"), class: "button button__sm button__secondary" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -21,6 +21,7 @@ ignore_unused:
   - "activemodel.attributes.custom_redirect.*"
   - "activemodel.attributes.user.*"
   - "activemodel.attributes.awesome_authorization_group.*"
+  - "activemodel.attributes.awesome_authorization_members.*"
   - "activemodel.attributes.organization.awesome_admins_available_authorizations"
   - "activemodel.attributes.force_authorization.*"
   - "activemodel.errors.models.cookie_item.attributes.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -323,6 +323,8 @@ en:
             email: Email
             new: Add new members
             no_members: This group has no members yet
+            not_synced: User authorizations are out of sync with this authorization
+              group. Please click on "Sync" to update the list of members.
             remove: Remove member
             title: Manage members for "%{group}"
             user: Decidim user

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,9 @@ en:
       awesome_authorization_group:
         name: Group name
         purpose: Group purpose
+      awesome_authorization_members:
+        emails: Emails
+        file: Upload a CSV file
       config:
         additional_proposal_sortings: Additional sorting options enabled
         allow_images_in_editors: Allow images in the HTML editor
@@ -308,6 +311,32 @@ en:
             name_help: This title is shown in the verification card.
             save: Save
             title: Edit authorization properties
+        awesome_authorization_users:
+          create:
+            error: Error updating members list! %{error}
+            success: Members list updated successfully (%{count} new users added)
+          destroy:
+            success: Member removed successfully
+          index:
+            authorized_user: Authorized user
+            confirm_remove: Are you sure you want to remove this member?
+            email: Email
+            new: Add new members
+            no_members: This group has no members yet
+            remove: Remove member
+            title: Manage members for "%{group}"
+            user: Decidim user
+          new:
+            create: Add members
+            emails_help: Drop emails here, only words with an "@" will be considered
+              as emails.
+            or: or
+            remove_previous_members: Remove previous members of the group (%{count}
+              users)
+            title: Add members to "%{group}"
+          update:
+            empty: No emails were found in the input or CSV file. Please add at least
+              one email.
         awesome_authorizations:
           create:
             error: Error creating authorization group! %{error}

--- a/spec/commands/admin/create_awesome_authorization_members_spec.rb
+++ b/spec/commands/admin/create_awesome_authorization_members_spec.rb
@@ -5,10 +5,21 @@ require "spec_helper"
 module Decidim::DecidimAwesome
   module Admin
     describe CreateAwesomeAuthorizationMembers do
-      subject { described_class.new(authorization_group, emails) }
+      subject { described_class.new(form) }
 
       let(:authorization_group) { create(:awesome_authorization_group) }
       let(:emails) { ["alice@example.org", "bob@example.org"] }
+      let(:form_params) do
+        {
+          emails: emails.join("\n"),
+          remove_previous_members: false
+        }
+      end
+      let(:form) do
+        AwesomeAuthorizationMembersForm.from_params(form_params).with_context(
+          authorization_group:
+        )
+      end
 
       describe "when valid" do
         it "broadcasts :ok" do

--- a/spec/commands/admin/create_awesome_authorization_members_spec.rb
+++ b/spec/commands/admin/create_awesome_authorization_members_spec.rb
@@ -51,6 +51,23 @@ module Decidim::DecidimAwesome
         it "does not create members" do
           expect { subject.call }.not_to change(Decidim::DecidimAwesome::AuthorizationMember, :count)
         end
+
+        context "when emails are nil" do
+          let(:form_params) do
+            {
+              emails: nil,
+              remove_previous_members: false
+            }
+          end
+
+          it "broadcasts :invalid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+
+          it "does not create members" do
+            expect { subject.call }.not_to change(Decidim::DecidimAwesome::AuthorizationMember, :count)
+          end
+        end
       end
     end
   end

--- a/spec/commands/admin/create_awesome_authorization_members_spec.rb
+++ b/spec/commands/admin/create_awesome_authorization_members_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::DecidimAwesome
+  module Admin
+    describe CreateAwesomeAuthorizationMembers do
+      subject { described_class.new(authorization_group, emails) }
+
+      let(:authorization_group) { create(:awesome_authorization_group) }
+      let(:emails) { ["alice@example.org", "bob@example.org"] }
+
+      describe "when valid" do
+        it "broadcasts :ok" do
+          expect { subject.call }.to broadcast(:ok)
+        end
+
+        it "creates missing members" do
+          expect { subject.call }.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(2)
+        end
+
+        context "when some members already exist" do
+          before do
+            create(:awesome_authorization_member, authorization_group:, email: "alice@example.org")
+          end
+
+          it "creates only new members" do
+            expect { subject.call }.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(1)
+          end
+        end
+      end
+
+      describe "when invalid" do
+        let(:emails) { ["not-an-email"] }
+
+        it "broadcasts :invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+
+        it "does not create members" do
+          expect { subject.call }.not_to change(Decidim::DecidimAwesome::AuthorizationMember, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/awesome_authorization_users_controller_spec.rb
+++ b/spec/controllers/admin/awesome_authorization_users_controller_spec.rb
@@ -43,11 +43,17 @@ module Decidim::DecidimAwesome
         end
 
         context "when using csv file" do
-          let(:csv_file) do
-            fixture_file_upload("authorization_members.csv", "text/csv")
+          let(:csv_blob) do
+            csv_path = File.expand_path("../../fixtures/files/authorization_members.csv", __dir__)
+
+            ActiveStorage::Blob.create_and_upload!(
+              io: StringIO.new(File.read(csv_path)),
+              filename: "authorization_members.csv",
+              content_type: "text/csv"
+            )
           end
           let(:params) do
-            base_params.merge(csv_file: csv_file)
+            base_params.merge(file: csv_blob.signed_id)
           end
 
           it "creates members from csv" do

--- a/spec/controllers/admin/awesome_authorization_users_controller_spec.rb
+++ b/spec/controllers/admin/awesome_authorization_users_controller_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::DecidimAwesome
+  module Admin
+    describe AwesomeAuthorizationUsersController do
+      routes { Decidim::DecidimAwesome::AdminEngine.routes }
+
+      let(:organization) { create(:organization, available_authorizations: ["awesome_authorization_handler"]) }
+      let(:user) { create(:user, :confirmed, :admin, organization:) }
+      let!(:authorization_group) { create(:awesome_authorization_group, organization:) }
+
+      before do
+        request.env["decidim.current_organization"] = user.organization
+        sign_in user, scope: :user
+      end
+
+      describe "GET #index" do
+        it "returns http success" do
+          get :index, params: { awesome_authorization_id: authorization_group.id }
+          expect(response).to have_http_status(:success)
+        end
+      end
+
+      describe "POST #create" do
+        let(:base_params) { { awesome_authorization_id: authorization_group.id } }
+
+        context "when using manual emails" do
+          let(:params) do
+            base_params.merge(emails: "alice@example.org\n bob@example.org")
+          end
+
+          it "creates members" do
+            expect { post :create, params: params }.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(2)
+          end
+
+          it "redirects with notice" do
+            post :create, params: params
+            expect(response).to have_http_status(:redirect)
+            expect(flash[:notice]).to be_present
+          end
+        end
+
+        context "when using csv file" do
+          let(:csv_file) do
+            fixture_file_upload("authorization_members.csv", "text/csv")
+          end
+          let(:params) do
+            base_params.merge(csv_file: csv_file)
+          end
+
+          it "creates members from csv" do
+            expect { post :create, params: params }.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(2)
+          end
+        end
+
+        context "when no valid input is provided" do
+          let(:params) { base_params.merge(emails: "") }
+
+          it "renders index with alert" do
+            post :create, params: params
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template(:index)
+            expect(flash[:alert]).to be_present
+          end
+        end
+      end
+
+      describe "DELETE #destroy" do
+        let!(:member) { create(:awesome_authorization_member, authorization_group:, email: "member@example.org") }
+
+        it "removes the member" do
+          expect do
+            delete :destroy, params: { awesome_authorization_id: authorization_group.id, id: member.id }
+          end.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(-1)
+        end
+
+        it "redirects with notice" do
+          delete :destroy, params: { awesome_authorization_id: authorization_group.id, id: member.id }
+          expect(response).to have_http_status(:redirect)
+          expect(flash[:notice]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/files/authorization_members.csv
+++ b/spec/fixtures/files/authorization_members.csv
@@ -1,0 +1,3 @@
+email
+carol@example.org
+david@example.org

--- a/spec/system/admin/admin_manages_awesome_authorizations_spec.rb
+++ b/spec/system/admin/admin_manages_awesome_authorizations_spec.rb
@@ -46,6 +46,94 @@ describe "Admin manages awesome authorizations" do
           }
         )
       end
+
+      it "allows creating an authorization group" do
+        click_on "Create a new authorization group"
+
+        fill_in_i18n :awesome_authorization_group_name,
+                     "#awesome_authorization_group-name-tabs",
+                     en: "Residents"
+        fill_in_i18n :awesome_authorization_group_purpose,
+                     "#awesome_authorization_group-name-tabs",
+                     en: "People registered in the city"
+        click_on "Create"
+
+        expect(page).to have_content("Authorization group created successfully")
+        expect(page).to have_content("Residents")
+
+        group = organization.awesome_authorization_groups.order(:id).last
+        expect(group.name["en"]).to eq("Residents")
+        expect(group.purpose["en"]).to eq("People registered in the city")
+      end
+
+      it "allows editing an authorization group" do
+        group = create(:awesome_authorization_group, organization:)
+
+        visit decidim_admin_decidim_awesome.awesome_authorizations_path
+        click_link_or_button "Edit group"
+
+        fill_in_i18n :awesome_authorization_group_name,
+                     "#awesome_authorization_group-name-tabs",
+                     en: "Verified residents"
+        fill_in_i18n :awesome_authorization_group_purpose,
+                     "#awesome_authorization_group-name-tabs",
+                     en: "Residents verified by the city"
+        click_on "Save"
+
+        expect(page).to have_content("Authorization group updated successfully")
+
+        group.reload
+        expect(group.name["en"]).to eq("Verified residents")
+        expect(group.purpose["en"]).to eq("Residents verified by the city")
+      end
+
+      it "allows destroying an authorization group" do
+        create(:awesome_authorization_group, organization:)
+
+        visit decidim_admin_decidim_awesome.awesome_authorizations_path
+
+        accept_confirm do
+          click_link_or_button "Destroy group"
+        end
+
+        expect(page).to have_content("Authorization group removed successfully")
+        expect(Decidim::DecidimAwesome::AuthorizationGroup.count).to eq(0)
+      end
+
+      it "allows managing members in a group" do
+        group = create(:awesome_authorization_group, organization:)
+
+        visit decidim_admin_decidim_awesome.awesome_authorization_users_path(group)
+
+        expect(page).to have_content("This group has no members yet")
+
+        click_on "Add new members"
+        fill_in "awesome_authorization_members_emails", with: "alice@example.org\nbob@example.org"
+        click_on "Add members"
+
+        expect(page).to have_content("Members list updated successfully")
+        expect(page).to have_content("alice@example.org")
+        expect(page).to have_content("bob@example.org")
+
+        expect do
+          within("tr", text: "alice@example.org") do
+            accept_confirm do
+              click_link_or_button "Remove member"
+            end
+          end
+        end.to change(Decidim::DecidimAwesome::AuthorizationMember, :count).by(-1)
+
+        expect(page).to have_content("Member removed successfully")
+      end
+
+      it "shows an out of sync warning when members and granted authorizations mismatch" do
+        group = create(:awesome_authorization_group, organization:)
+        create(:awesome_authorization_member, authorization_group: group, email: admin.email)
+
+        visit decidim_admin_decidim_awesome.awesome_authorization_users_path(group)
+
+        expect(page).to have_content("out of sync with this authorization group")
+      end
     end
 
     context "when authorization is not available in organization" do


### PR DESCRIPTION
fixes #606 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin workflow to view, add, and remove authorization group members.
  * Supported adding members by entering emails or uploading a CSV file.
  * Added clearer admin messaging, including success, error, empty-state, and out-of-sync warnings.

* **Bug Fixes**
  * Improved handling of duplicate and invalid member entries during bulk additions.
  * Kept member lists sorted and paginated for easier browsing.

* **Documentation**
  * Added and updated translations for the new admin screens and member-related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->