### PR TITLE
0.32 upgrade (2): Proposal voting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: "[CI] Tests 0.31"
+name: "[CI] Tests 0.32"
 
 on:
   push:
@@ -74,6 +74,11 @@ jobs:
           path: ./spec/decidim_dummy_app/
           key: app-${{ github.sha }}
           restore-keys: app-${{ github.sha }}
+
+      - run: |
+          sudo apt update
+          sudo apt install -y libvips libvips-tools
+        name: Install libvips
 
       - run: bundle exec rake test_app
         name: Create test app
@@ -162,7 +167,7 @@ jobs:
         name: Install Chrome version
 
       - run: |
-          sudo apt install wkhtmltopdf imagemagick 7zip
+          sudo apt install wkhtmltopdf imagemagick 7zip libvips libvips-tools
 
       - uses: actions/download-artifact@v4
         with:

--- a/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/needs_hashcash.rb
@@ -11,7 +11,7 @@ module Decidim
 
         helper_method :awesome_hashcash_bits
         before_action :set_hashcash_bits
-        before_action :awesome_check_hashcash, only: :create # rubocop:disable Rails/LexicallyScopedActionFilter
+        before_action :awesome_check_hashcash, if: -> { action_name == "create" }
       end
 
       private

--- a/app/controllers/concerns/decidim/decidim_awesome/proposals/proposal_votes_controller_override.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/proposals/proposal_votes_controller_override.rb
@@ -32,7 +32,7 @@ module Decidim
               end
 
               on(:invalid) do
-                render json: { error: I18n.t("proposal_votes.create.error", scope: "decidim.proposals") }, status: :unprocessable_entity
+                render json: { error: I18n.t("proposal_votes.create.error", scope: "decidim.proposals") }, status: :unprocessable_content
               end
             end
           end
@@ -43,7 +43,7 @@ module Decidim
             return unless vote_manifest
             return if vote_manifest.valid_weight? weight, user: current_user, proposal: proposal
 
-            render json: { error: I18n.t("proposal_votes.create.error", scope: "decidim.proposals") }, status: :unprocessable_entity
+            render json: { error: I18n.t("proposal_votes.create.error", scope: "decidim.proposals") }, status: :unprocessable_content
           end
 
           def current_vote

--- a/app/packs/src/decidim/decidim_awesome/amendments/show_modal_on_limits.js
+++ b/app/packs/src/decidim/decidim_awesome/amendments/show_modal_on_limits.js
@@ -3,7 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const modalEl = document.getElementById(modalId);
   const limitAmendments = modalEl && JSON.parse(modalEl.dataset.limitAmendments);
 
-  if (!limitAmendments || document.querySelector('a[href^="/users/sign_in"]')) {
+  if (!limitAmendments || document.querySelector('a[href*="/users/sign_in"]')) {
     return;
   }
 

--- a/app/packs/src/decidim/decidim_awesome/voting/voting_cards.js
+++ b/app/packs/src/decidim/decidim_awesome/voting/voting_cards.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
-  if (!document.querySelector('[href="/users/sign_out"]')) {
+  if (!document.querySelector('[href$="/users/sign_out"]')) {
     return;
   }
 

--- a/lib/decidim/decidim_awesome/checksums.yml
+++ b/lib/decidim/decidim_awesome/checksums.yml
@@ -78,7 +78,7 @@ decidim-proposals:
   /app/helpers/decidim/proposals/application_helper.rb:
     decidim-0.31.0: 6210b3b088bec19e76fda73d42297ccc
   /app/controllers/decidim/proposals/proposal_votes_controller.rb:
-    decidim-0.31.0: f983e72c1ee8d31222d537533c762cd2
+    decidim-0.32.0: 6f1ec5dd149d22acd246b77982e823cf
   /app/views/decidim/proposals/admin/proposals/_form.html.erb:
     decidim-0.31.0: 3c6d2675fa774c888150dc8da494fee0
     decidim-0.31.6: 4752eb6a8b403912c9f686999c1860c5
@@ -101,7 +101,7 @@ decidim-proposals:
     decidim-0.31.0: b8b19a77296da757ea0e827d6decd596
     decidim-0.31.6: 865d302d783b1f0e7353cf440600d972
   /app/cells/decidim/proposals/proposal_votes_count_cell.rb:
-    decidim-0.31.6: 60539661178d8cb19cd70bd18c8253f4
+    decidim-0.32.0: bdde0cfe1e3d1459d0fe75f9697cba90
   /app/cells/decidim/proposals/proposal_votes_count/show.erb:
     decidim-0.31.6: 2e08a1fccd2ec84706fbca392cd7bf66
   /app/views/decidim/proposals/proposal_votes/update_buttons_and_counters.js.erb:
@@ -127,10 +127,9 @@ decidim-proposals:
     decidim-0.31.0: a82899d804c96fc40b3e1fade979e827
     decidim-0.31.1: 400df0fffc5fa1b52ef09344409d5c78
   /app/views/decidim/proposals/proposals/index.html.erb:
-    decidim-0.31.0: 573b29b837fdd0f283be5be942c05aac
-    decidim-0.31.2: cd4be96ca73de79b0f8d82f0f80f00e7
+    decidim-0.32.0: e3733b41a9bb2feca2faa1c0ef725ee3
   /app/views/decidim/proposals/proposals/show.html.erb:
-    decidim-0.31.0: e2c0adf5c283f7396d93207e1b7ab740
+    decidim-0.32.0: 54c1771d6aa2563e15d5fb688a721378
 decidim-verifications:
   /app/helpers/decidim/verifications/application_helper.rb:
     decidim-0.31.0: 9f40fba8f2f7f16d588b8bcad4300376

--- a/spec/lib/system_checker_spec.rb
+++ b/spec/lib/system_checker_spec.rb
@@ -28,12 +28,12 @@ module Decidim::DecidimAwesome
       expect(subject.overrides["decidim-conferences"].files.length).to eq(1)
     end
 
-    it "has 23 modified files in core" do
-      expect(subject.overrides["decidim-core"].files.length).to eq(23)
+    it "has 22 modified files in core" do
+      expect(subject.overrides["decidim-core"].files.length).to eq(22)
     end
 
-    it "has 28 modified files in proposals" do
-      expect(subject.overrides["decidim-proposals"].files.length).to eq(28)
+    it "has 26 modified files in proposals" do
+      expect(subject.overrides["decidim-proposals"].files.length).to eq(26)
     end
 
     it "has 1 modified files in verifications" do


### PR DESCRIPTION
Adapts the proposal voting features (voting cards, weighted voting, votes by status) to Decidim 0.32.

- Mirror the Rack 3 status rename (`unprocessable_content`) in the proposal votes controller override
- Fix login detection in `voting_cards.js` and `show_modal_on_limits.js`: 0.32 adds locale prefixes to all URLs, so exact-match href selectors stopped matching and the voting modal never opened
- Replace `only: :create` with a runtime guard in the hashcash callback (Rails 7.1 raises on callbacks referencing missing actions; the concern is included into all controllers)
- Update checksums for the four upstream files changed in 0.32 (index/show views, votes controller, votes count cell), deface anchors verified intact