### PR TITLE
0.32 upgrade (3): Locale-prefixed URLs

### DIFF
--- a/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
@@ -6,7 +6,7 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
-        before_action :redirect_unallowed_scoped_admins, only: :not_found, if: -> { request.original_fullpath =~ %r{^(/+)admin} }
+        before_action :redirect_unallowed_scoped_admins, only: :not_found, if: -> { ContextAnalyzers::RequestAnalyzer.strip_locale(request.original_fullpath) =~ %r{^(/+)admin} }
         before_action :redirect_to_custom_paths, only: :not_found, if: -> { DecidimAwesome.enabled? :custom_redirects }
         private
 
@@ -38,11 +38,11 @@ module Decidim
         end
 
         def custom_redirects_destination(fullpath)
-          redirects = (AwesomeConfig.find_by(var: :custom_redirects, organization: current_organization)&.value || {}).filter { |_, v| v["active"] }
+          redirects = active_custom_redirects
           return if redirects.blank?
-          return unless redirects.is_a? Hash
 
           path, query = fullpath.split("?")
+          path = ContextAnalyzers::RequestAnalyzer.strip_locale(path)
           destination = redirects.dig(path, "destination")
           pass_query = redirects.dig(path, "pass_query")
           if pass_query.present?
@@ -50,7 +50,15 @@ module Decidim
             destination = "#{destination}#{union}#{query}"
           end
 
-          destination.strip if destination.present?
+          destination.presence&.strip
+        end
+
+        # origins are stored without the locale prefix (see Admin::CustomRedirectForm)
+        def active_custom_redirects
+          redirects = AwesomeConfig.find_by(var: :custom_redirects, organization: current_organization)&.value
+          return unless redirects.is_a? Hash
+
+          redirects.filter { |_, v| v["active"] }
         end
       end
     end

--- a/app/forms/decidim/decidim_awesome/admin/custom_redirect_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/custom_redirect_form.rb
@@ -5,6 +5,7 @@ module Decidim
     module Admin
       class CustomRedirectForm < Decidim::Form
         include Decidim::TranslatableAttributes
+
         attribute :origin, String
         attribute :destination, String
         attribute :active, Boolean
@@ -15,7 +16,7 @@ module Decidim
 
         def to_params
           [
-            sanitize_url(origin),
+            normalized_origin,
             {
               destination: sanitize_url(destination, strip_host: false),
               active:,
@@ -32,10 +33,14 @@ module Decidim
           url
         end
 
+        def normalized_origin
+          ContextAnalyzers::RequestAnalyzer.strip_locale(sanitize_url(origin))
+        end
+
         private
 
         def different_origin_destination
-          return if sanitize_url(origin) != sanitize_url(destination)
+          return if normalized_origin != sanitize_url(destination)
 
           errors.add(:destination, :invalid)
         end

--- a/app/forms/decidim/decidim_awesome/admin/menu_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/menu_form.rb
@@ -5,6 +5,7 @@ module Decidim
     module Admin
       class MenuForm < Decidim::Form
         include Decidim::TranslatableAttributes
+
         VISIBILITY_STATES = %w(default hidden logged non_logged verified_user).freeze
 
         translatable_attribute :raw_label, String
@@ -21,14 +22,14 @@ module Decidim
 
         # remove query string from native menu element (to avoid interactions with the locale in the generated url)
         def map_model(model)
-          self.url = Addressable::URI.parse(model.url).path if model.native?
+          self.url = ContextAnalyzers::RequestAnalyzer.strip_locale(Addressable::URI.parse(model.url).path) if model.native?
         end
 
         def to_params
           {
             label: raw_label,
             position:,
-            url:,
+            url: ContextAnalyzers::RequestAnalyzer.strip_locale(url),
             target:,
             visibility:
           }

--- a/app/packs/stylesheets/decidim/decidim_awesome/admin/auto_edits.scss
+++ b/app/packs/stylesheets/decidim/decidim_awesome/admin/auto_edits.scss
@@ -3,7 +3,7 @@ a.awesome-auto-edit {
 }
 
 a.awesome-auto-delete {
-  @apply float-right;
+  @apply float-right inline-flex items-center gap-1;
 }
 
 .form-defaults input[type="text"].awesome-auto-edit {

--- a/lib/decidim/decidim_awesome/admin_engine.rb
+++ b/lib/decidim/decidim_awesome/admin_engine.rb
@@ -60,7 +60,11 @@ module Decidim
 
       initializer "decidim_decidim_awesome.admin_mount_routes" do
         Decidim::Core::Engine.routes do
-          mount Decidim::DecidimAwesome::AdminEngine, at: "/admin/decidim_awesome", as: "decidim_admin_decidim_awesome"
+          extend Decidim::Routes::LocaleRedirects
+
+          scope "/:locale", **locale_scope_options do
+            mount Decidim::DecidimAwesome::AdminEngine, at: "/admin/decidim_awesome", as: "decidim_admin_decidim_awesome"
+          end
         end
       end
 

--- a/lib/decidim/decidim_awesome/checksums.yml
+++ b/lib/decidim/decidim_awesome/checksums.yml
@@ -36,7 +36,7 @@ decidim-core:
     decidim-0.31.5: 87fdd56ff853f05f8ab4499c9f5d1b42
     decidim-0.31.6: 39c8465d536cc71908d67724d8cd3f54
   /app/helpers/decidim/amendments_helper.rb:
-    decidim-0.31.0: db42be326ff225c422e2c126d784b477
+    decidim-0.32.0: 30838c0b02d81124badac4324cc7cad5
   /app/presenters/decidim/admin_log/component_presenter.rb:
     decidim-0.31.0: 0bfbd6771f52884a224f8e947ab15839
   /app/forms/decidim/account_form.rb:
@@ -67,7 +67,7 @@ decidim-proposals:
   /lib/decidim/proposals/proposal_serializer.rb:
     decidim-0.31.0: eadfc45fe2e1388d579a7ffa2f87c478
   /lib/decidim/api/proposal_type.rb:
-    decidim-0.31.0: 6412531f810db349abb779eec9f7b26d
+    decidim-0.32.0: c504eea4a293d0783854f745ebfd0af8
   /app/forms/decidim/proposals/proposal_form.rb:
     decidim-0.31.0: ffa0fa0d38a9c77d73d173727bc87cd2
     decidim-0.31.6: c11599fd60fc1c974d2958f3b4c8ab52
@@ -76,7 +76,7 @@ decidim-proposals:
     decidim-0.31.3: c222792947e0bac2cd4869adb5ce13bb
     decidim-0.31.6: 5c6cc25fddd1964b2027eb92536268dd
   /app/helpers/decidim/proposals/application_helper.rb:
-    decidim-0.31.0: 6210b3b088bec19e76fda73d42297ccc
+    decidim-0.32.0: 8d4f7a7598f10f1b6123533bee8fbd3a
   /app/controllers/decidim/proposals/proposal_votes_controller.rb:
     decidim-0.32.0: 6f1ec5dd149d22acd246b77982e823cf
   /app/views/decidim/proposals/admin/proposals/_form.html.erb:
@@ -108,7 +108,7 @@ decidim-proposals:
     decidim-0.31.0: d6aff3371847210fd74673310bf76a86
     decidim-0.31.6: 96318bac2808ca4af7e53c9bf6015091
   /app/permissions/decidim/proposals/permissions.rb:
-    decidim-0.31.0: a8b29ebc1ac11ac00f90b5848343b9b4
+    decidim-0.32.0: e6068b2b9c8187bd1be34c5000597c0d
   /app/cells/decidim/proposals/proposal_metadata_cell.rb:
     decidim-0.31.0: f2034b32638869b49ad500abc9724edf
   /app/commands/decidim/proposals/create_proposal.rb:

--- a/lib/decidim/decidim_awesome/context_analyzers/request_analyzer.rb
+++ b/lib/decidim/decidim_awesome/context_analyzers/request_analyzer.rb
@@ -24,6 +24,16 @@ module Decidim
             end
             spaces
           end
+
+          # Strips the leading locale segment ("/en/processes/..." => "/processes/...")
+          # so paths can be compared and mapped to spaces regardless of the locale.
+          # Anything not starting with "/" (external urls, blanks) is left untouched.
+          def strip_locale(path)
+            return path if path.blank?
+
+            stripped = path.sub(%r{\A/#{Regexp.union(I18n.available_locales.map(&:to_s))}(?=/|\z)}, "")
+            stripped.empty? ? "/" : stripped
+          end
         end
 
         def initialize(request)
@@ -83,6 +93,7 @@ module Decidim
         end
 
         def context_from_path(path)
+          path = RequestAnalyzer.strip_locale(path)
           if system_manifest?(path)
             @context[:participatory_space_manifest] = "system"
             return

--- a/lib/decidim/decidim_awesome/engine.rb
+++ b/lib/decidim/decidim_awesome/engine.rb
@@ -445,6 +445,7 @@ module Decidim
       end
 
       initializer "decidim_decidim_awesome.register_icons" do
+        Decidim.icons.register(name: "spy-line", icon: "spy-line", category: "system", description: "", engine: :decidim_awesome)
         Decidim.icons.register(name: "editors-text", icon: "text", category: "system", description: "", engine: :decidim_awesome)
         Decidim.icons.register(name: "surveys", icon: "survey-line", category: "system", description: "", engine: :decidim_awesome)
         Decidim.icons.register(name: "brush", icon: "brush-line", category: "system", description: "", engine: :decidim_awesome)

--- a/lib/decidim/decidim_awesome/menu_hacker.rb
+++ b/lib/decidim/decidim_awesome/menu_hacker.rb
@@ -4,6 +4,7 @@ module Decidim
   module DecidimAwesome
     class MenuHacker
       include Decidim::TranslatableAttributes
+      include Decidim::Routes::LocaleRedirects
 
       def initialize(name, view)
         @name = name
@@ -18,11 +19,11 @@ module Decidim
 
         @items = default_items
         menu_overrides.each do |item|
-          default = default_items.find { |i| i.url.gsub(/\?.*/, "") == item.url }
+          default = default_items.find { |i| same_url?(i.url.gsub(/\?.*/, ""), item.url) }
           if default
             item.send("overridden?=", true)
             item[:original_active] = default.active
-            @items.reject! { |i| i.url.gsub(/\?.*/, "") == item.url }
+            @items.reject! { |i| same_url?(i.url.gsub(/\?.*/, ""), item.url) }
           end
           @items << item
         end
@@ -51,7 +52,7 @@ module Decidim
           OpenStruct.new(
             label: translated_attribute(item["label"], organization),
             raw_label: item["label"],
-            url: item["url"],
+            url: localized_url(item["url"]),
             position: item["position"] || 1,
             # see options in https://github.com/comfy/active_link_to
             active: method(:activate?),
@@ -64,8 +65,25 @@ module Decidim
       end
 
       def activate?(url, view)
-        urls = @items.map(&:url).sort_by(&:length).reverse
-        url == urls.find { |u| view.request.original_fullpath.start_with?(u) }
+        current_path = strip_locale(view.request.original_fullpath)
+        urls = @items.map(&:url).sort_by { |u| strip_locale(u).length }.reverse
+        url == urls.find { |u| current_path.start_with?(strip_locale(u)) }
+      end
+
+      # Renders local paths with the current locale prefix, external urls untouched
+      def localized_url(url)
+        return url if url.blank? || !url.start_with?("/")
+
+        append_locale(strip_locale(url), I18n.locale)
+      end
+
+      # menu urls are compared ignoring the locale prefix
+      def same_url?(first, second)
+        strip_locale(first) == strip_locale(second)
+      end
+
+      def strip_locale(url)
+        ContextAnalyzers::RequestAnalyzer.strip_locale(url)
       end
 
       def visible?(item)
@@ -86,7 +104,7 @@ module Decidim
       end
 
       def current_config
-        @current_config ||= (AwesomeConfig.find_by(var: name, organization:)&.value || []).filter { |i| i.is_a? Hash }
+        @current_config ||= (AwesomeConfig.find_by(var: name, organization:)&.value || []).grep(Hash)
       end
     end
   end

--- a/lib/decidim/decidim_awesome/middleware/current_config.rb
+++ b/lib/decidim/decidim_awesome/middleware/current_config.rb
@@ -30,6 +30,11 @@ module Decidim
 
       private
 
+      # request path without the locale prefix, comparable with the route patterns below
+      def request_path
+        @request_path ||= ContextAnalyzers::RequestAnalyzer.strip_locale(@request.path)
+      end
+
       # a workaround to set a flash message if coming from the error controller (route not found)
       def add_flash_message_from_request(env)
         return unless scoped_admins_active?
@@ -86,7 +91,7 @@ module Decidim
         return true if safe_get_route?
 
         spaces = ContextAnalyzers::RequestAnalyzer.participatory_spaces_routes.keys.join("|^(/admin){0,1}/")
-        case @request.path
+        case request_path
         when %r{"|^(/admin){0,1}/#{spaces}}
           true
         when %r{^/admin/}
@@ -97,7 +102,7 @@ module Decidim
       def safe_get_route?
         return false unless @request.get?
 
-        case @request.path
+        case request_path
         when "/"
           true
         when "/admin/"
@@ -112,7 +117,7 @@ module Decidim
       def safe_post_route?
         return false unless @request.post? || @request.put? || @request.patch?
 
-        case @request.path
+        case request_path
         when %r{^/admin/admin_terms}
           true
         end

--- a/spec/lib/context_analyzers/request_analyzer_spec.rb
+++ b/spec/lib/context_analyzers/request_analyzer_spec.rb
@@ -17,7 +17,18 @@ module Decidim::DecidimAwesome
 
       paths = {
         "/" => {},
+        "/en" => {},
         "/processes" => { participatory_space_manifest: "participatory_processes" },
+        "/en/processes" => { participatory_space_manifest: "participatory_processes" },
+        "/ca/assemblies/some-assembly/f/12" => {
+          participatory_space_manifest: "assemblies",
+          participatory_space_slug: "some-assembly",
+          component_id: "12"
+        },
+        "https://www.decidim.barcelona/en/processes/PressupostosParticipatius" => {
+          participatory_space_manifest: "participatory_processes",
+          participatory_space_slug: "PressupostosParticipatius"
+        },
         "/processes_groups" => { participatory_space_manifest: "process_groups" },
         "/processes_groups/123" => { participatory_space_manifest: "process_groups", participatory_space_slug: "123" },
         "https://www.decidim.barcelona/processes/" => { participatory_space_manifest: "participatory_processes" },
@@ -44,7 +55,9 @@ module Decidim::DecidimAwesome
 
       admin_paths = {
         "/admin" => {},
+        "/en/admin" => {},
         "/admin/participatory_processes" => { participatory_space_manifest: "participatory_processes" },
+        "/en/admin/participatory_processes" => { participatory_space_manifest: "participatory_processes" },
         "/admin/participatory_process_groups" => { participatory_space_manifest: "process_groups" },
         "/admin/assemblies" => { participatory_space_manifest: "assemblies" },
         "/admin/assemblies_types" => { participatory_space_manifest: "assemblies" },

--- a/spec/system/public/menu_hacks_spec.rb
+++ b/spec/system/public/menu_hacks_spec.rb
@@ -36,13 +36,13 @@ describe "Hacked menus" do
 
   shared_examples "has active link" do |text|
     it "has only one active link" do
-      within "#main-dropdown-menu" do
+      within "#dropdown-menu-main-desktop" do
         expect(page).to have_css("li.active", count: 1)
       end
     end
 
     it "active link contains text" do
-      within "#main-dropdown-menu .active" do
+      within "#dropdown-menu-main-desktop .active" do
         expect(page).to have_content(text)
       end
     end
@@ -52,11 +52,11 @@ describe "Hacked menus" do
     before do
       switch_to_host(organization.host)
       visit decidim_participatory_processes.participatory_processes_path
-      find_by_id("main-dropdown-summary").hover
+      find_by_id("main-dropdown-summary-desktop").click
     end
 
     it "renders the hacked menu" do
-      within "#main-dropdown-menu" do
+      within "#dropdown-menu-main-desktop" do
         expect(page).to have_no_content("Home")
         expect(page).to have_content("Processes")
         expect(page).to have_content("A new beginning")
@@ -65,13 +65,13 @@ describe "Hacked menus" do
     end
 
     it "renders in the proper order" do
-      within "#main-dropdown-menu li:nth-child(1)" do
+      within "#dropdown-menu-main-desktop li:nth-child(1)" do
         expect(page).to have_content("Processes")
       end
-      within "#main-dropdown-menu li:nth-child(2)" do
+      within "#dropdown-menu-main-desktop li:nth-child(2)" do
         expect(page).to have_content("Blog")
       end
-      within "#main-dropdown-menu li:last-child" do
+      within "#dropdown-menu-main-desktop li:last-child" do
         expect(page).to have_content("A new beginning")
       end
     end
@@ -89,9 +89,9 @@ describe "Hacked menus" do
       end
 
       it "has target blank" do
-        expect(find("#main-dropdown-menu li:nth-child(2) a")["data-remote"]).to eq("true")
-        expect(find("#main-dropdown-menu li:nth-child(2) a")[:target]).to eq("_blank")
-        expect(find("#main-dropdown-menu li:last-child a")["data-remote"]).not_to eq("true")
+        expect(find("#dropdown-menu-main-desktop li:nth-child(2) a")["data-remote"]).to eq("true")
+        expect(find("#dropdown-menu-main-desktop li:nth-child(2) a")[:target]).to eq("_blank")
+        expect(find("#dropdown-menu-main-desktop li:last-child a")["data-remote"]).not_to eq("true")
       end
     end
 
@@ -109,7 +109,7 @@ describe "Hacked menus" do
       end
 
       it "renders the item" do
-        within "#main-dropdown-menu" do
+        within "#dropdown-menu-main-desktop" do
           expect(page).to have_content("A new beginning")
         end
       end
@@ -118,7 +118,7 @@ describe "Hacked menus" do
         let(:visibility) { "hidden" }
 
         it "do not show the menu item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_no_content("A new beginning")
           end
         end
@@ -128,7 +128,7 @@ describe "Hacked menus" do
         let(:visibility) { "logged" }
 
         it "do not show the menu item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_no_content("A new beginning")
           end
         end
@@ -138,7 +138,7 @@ describe "Hacked menus" do
         let(:visibility) { "non_logged" }
 
         it "do not show the menu item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_content("A new beginning")
           end
         end
@@ -149,7 +149,7 @@ describe "Hacked menus" do
       let(:disabled_features) { [:menu] }
 
       it "renders the normal menu" do
-        within "#main-dropdown-menu" do
+        within "#dropdown-menu-main-desktop" do
           expect(page).to have_content("Home")
           expect(page).to have_content("Processes")
           expect(page).to have_no_content("A new beginning")
@@ -188,7 +188,7 @@ describe "Hacked menus" do
       context "when visiting all processes list" do
         before do
           visit decidim_participatory_processes.participatory_processes_path
-          find_by_id("main-dropdown-summary").hover
+          find_by_id("main-dropdown-summary-desktop").click
         end
 
         it_behaves_like "has active link", "A new beginning"
@@ -197,7 +197,7 @@ describe "Hacked menus" do
       context "when visiting a process in a custom link" do
         before do
           visit decidim_participatory_processes.participatory_process_path(participatory_process.slug)
-          find_by_id("main-dropdown-summary").hover
+          find_by_id("main-dropdown-summary-desktop").click
         end
 
         it_behaves_like "has active link", "A single process"
@@ -206,7 +206,7 @@ describe "Hacked menus" do
       context "when visiting a sublink of a process in a custom link" do
         before do
           visit main_component_path(component)
-          find_by_id("main-dropdown-summary").hover
+          find_by_id("main-dropdown-summary-desktop").click
         end
 
         it_behaves_like "has active link", "A single process"
@@ -215,7 +215,7 @@ describe "Hacked menus" do
       context "when visiting a process not in a custom link" do
         before do
           visit decidim_participatory_processes.participatory_process_path(participatory_process2.slug)
-          find_by_id("main-dropdown-summary").hover
+          find_by_id("main-dropdown-summary-desktop").click
         end
 
         it_behaves_like "has active link", "A new beginning"
@@ -224,7 +224,7 @@ describe "Hacked menus" do
       context "when visiting a sublink of a process not in a custom link" do
         before do
           visit main_component_path(component2)
-          find_by_id("main-dropdown-summary").hover
+          find_by_id("main-dropdown-summary-desktop").click
         end
 
         it_behaves_like "has active link", "A new beginning"
@@ -251,14 +251,14 @@ describe "Hacked menus" do
       switch_to_host(organization.host)
       login_as user, scope: :user
       visit decidim_participatory_processes.participatory_processes_path
-      find_by_id("main-dropdown-summary").hover
+      find_by_id("main-dropdown-summary-desktop").click
     end
 
     context "when hidden" do
       let(:visibility) { "hidden" }
 
       it "do not show the menu item" do
-        within "#main-dropdown-menu" do
+        within "#dropdown-menu-main-desktop" do
           expect(page).to have_no_content("A new beginning")
         end
       end
@@ -268,7 +268,7 @@ describe "Hacked menus" do
       let(:visibility) { "logged" }
 
       it "do not show the menu item" do
-        within "#main-dropdown-menu" do
+        within "#dropdown-menu-main-desktop" do
           expect(page).to have_content("A new beginning")
         end
       end
@@ -278,7 +278,7 @@ describe "Hacked menus" do
       let(:visibility) { "non_logged" }
 
       it "do not show the menu item" do
-        within "#main-dropdown-menu" do
+        within "#dropdown-menu-main-desktop" do
           expect(page).to have_no_content("A new beginning")
         end
       end
@@ -290,7 +290,7 @@ describe "Hacked menus" do
 
       context "when user is verified" do
         it "shows the item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_content("A new beginning")
           end
         end
@@ -300,7 +300,7 @@ describe "Hacked menus" do
         let(:authorization) { nil }
 
         it "shows the item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_no_content("A new beginning")
           end
         end
@@ -310,7 +310,7 @@ describe "Hacked menus" do
         let!(:authorization) { create(:authorization, granted_at: 3.months.ago, user:, name: "dummy_authorization_handler") }
 
         it "shows the item" do
-          within "#main-dropdown-menu" do
+          within "#dropdown-menu-main-desktop" do
             expect(page).to have_no_content("A new beginning")
           end
         end


### PR DESCRIPTION
Adapts the module to the locale-prefixed URLs introduced in Decidim 0.32.

- [x] Add `RequestAnalyzer.strip_locale` and use it everywhere paths are parsed or compared (scoped constraints, menu hacks, custom redirects, scoped admins middleware)
- [x] Store menu hack urls and redirect origins without the locale prefix; render menu links with the current locale via the core `append_locale` helper
- [x] Mount the admin engine inside the locale scope 
- [x] Register the `spy-line` icon
- [x] Update menu specs to the new 0.32 header markup
- [x] Update checksums for the proposals files changed upstream — our overrides are not affected, custom fields verified manually