### PR TITLE
0.32 upgrade (5): Forced verifications

### DIFF
--- a/app/packs/src/decidim/decidim_awesome/admin/auto_edit.js
+++ b/app/packs/src/decidim/decidim_awesome/admin/auto_edit.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const attribute = target.dataset.var;
       const inputFields = document.querySelectorAll(`[name="config[${attribute}][${key}]"]`);
       const multipleFields = document.querySelectorAll(`[name="config[${attribute}][${key}][]"]`);
-      const subFields = document.querySelectorAll(`[name^="config[${attribute}[${key}]]"]`);
+      const subFields = document.querySelectorAll(`[name^="config[${attribute}][${key}]["]`);
       const container = document.querySelector(`.js-box-container[data-key="${key}"]`);
       const deleteBox = container.querySelector(".awesome-auto-delete");
 
@@ -46,8 +46,8 @@ document.addEventListener("DOMContentLoaded", () => {
         if (subFields.length > 0) {
           subFields.forEach((subField) => {
             subField.setAttribute("name", subField.getAttribute("name").replace(
-              `config[${attribute}[${key}]]`,
-              `config[${attribute}[${result.key}]]`
+              `config[${attribute}][${key}]`,
+              `config[${attribute}][${result.key}]`
             ));
           });
         }
@@ -86,15 +86,18 @@ document.addEventListener("DOMContentLoaded", () => {
       input.focus();
       let config = {};
       config[attribute] = true;
+      // Rebuilding the label removes the focused input, which fires a "blur"
+      // that would revert the freshly saved key
+      let saving = false;
       let token = document.querySelector('meta[name="csrf-token"]');
-      input.addEventListener("keypress", (evt) => {
+      input.addEventListener("keydown", (evt) => {
         if (evt.key === "Enter" || evt.keyCode === 13 || evt.keyCode ===  10) {
+          evt.preventDefault();
           if (key === input.value) {
             rebuildLabel(key);
             return;
           }
-          // console.log("Saving key", key, "to", input.value, "with scope", scope);
-          evt.preventDefault();
+          saving = true;
           fetch(window.DecidimAwesome.renameScopeLabelPath, {
             method: "POST",
             headers: {
@@ -121,7 +124,9 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       input.addEventListener("blur", () => {
-        rebuildLabel(key);
+        if (!saving) {
+          rebuildLabel(key);
+        }
       });
     });
   });

--- a/app/views/decidim/decidim_awesome/admin/config/_form_verifications.html.erb
+++ b/app/views/decidim/decidim_awesome/admin/config/_form_verifications.html.erb
@@ -12,7 +12,7 @@
     <% form.object.force_authorizations&.each do |key, group| %>
       <% group ||= Decidim::DecidimAwesome::Admin::AuthorizationGroupForm.new %>
 
-      <%= form.fields_for "#{config_var}[#{key}]", group do |group_form| %>
+      <%= fields_for "config[#{config_var}][#{key}]", group do |group_form| %>
         <div class="card p-4 js-box-container force_authorization_container" data-key="<%= key %>" data-var="<%= config_var %>">
           <%= render "decidim/decidim_awesome/admin/config/autoedit_box_label", var: config_var, key:, scope: "#{field}_#{key}", delete_path: decidim_admin_decidim_awesome.force_authorization_path(key:) %>
           <div class="card-section mt-2">

--- a/spec/controllers/forced_authorization_spec.rb
+++ b/spec/controllers/forced_authorization_spec.rb
@@ -14,6 +14,7 @@ module Decidim::DecidimAwesome
   describe ApplicationController do
     routes { Decidim::DecidimAwesome::Engine.routes }
     before do
+      Rails.application.reload_routes_unless_loaded
       Decidim::DecidimAwesome::Engine.routes.draw do
         get "index" => "test#index"
       end
@@ -55,7 +56,7 @@ module Decidim::DecidimAwesome
       it "redirects to the login page" do
         get :index
         expect(response).to have_http_status(:found)
-        expect(response).to redirect_to("/users/sign_in")
+        expect(response).to redirect_to("/en/users/sign_in")
       end
     end
 

--- a/spec/system/public/forced_verifications_spec.rb
+++ b/spec/system/public/forced_verifications_spec.rb
@@ -6,6 +6,8 @@ describe "Forced verifications" do
   let(:organization) { create(:organization, available_authorizations: [:dummy_authorization_handler, :another_dummy_authorization_handler]) }
   let!(:user) { create(:user, :confirmed, organization:) }
   let(:restricted_path) { "/" }
+  let(:localized_redirect) { restricted_path == "/" ? "/en" : "/en#{restricted_path}" }
+  let(:localized_restricted_path) { restricted_path == "/" ? "/en/" : "/en#{restricted_path}" }
   let(:key) { "default" }
   let!(:force_authorizations_config) do
     create(
@@ -37,7 +39,7 @@ describe "Forced verifications" do
     end
 
     it "page cannot be visited" do
-      expect(page).to have_current_path(decidim.new_user_session_path(redirect_url: restricted_path))
+      expect(page).to have_current_path(decidim.new_user_session_path(redirect_url: localized_redirect))
     end
   end
 
@@ -50,7 +52,7 @@ describe "Forced verifications" do
     end
 
     it "user is redirected to the required authorizations page" do
-      expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+      expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
       expect(page).to have_content("you need to authorize your account with a valid authorization")
       expect(page).to have_content("lease verify yourself with all these methods before being able to access the platform")
       expect(page).to have_content("Verify with Example authorization")
@@ -69,7 +71,7 @@ describe "Forced verifications" do
       click_on "Verify with Another example authorization"
       fill_in "Passport number", with: "A12345678"
       click_on "Send"
-      expect(page).to have_current_path(restricted_path, ignore_query: true)
+      expect(page).to have_current_path(localized_redirect, ignore_query: true)
     end
 
     it "user can logout" do
@@ -83,19 +85,19 @@ describe "Forced verifications" do
       expect(page).to have_current_path("/authorizations")
 
       visit "/account"
-      expect(page).to have_current_path("/account")
+      expect(page).to have_current_path("/en/account")
 
       visit "/pages"
-      expect(page).to have_current_path("/pages")
+      expect(page).to have_current_path("/en/pages")
     end
 
     context "when the user has not accepted the terms an conditions" do
       let(:user) { create(:user, :confirmed, organization:, accepted_tos_version: nil) }
 
       it "user can accept the terms and conditions" do
-        expect(page).to have_current_path("/pages/terms-of-service")
+        expect(page).to have_current_path("/en/pages/terms-of-service")
         click_on "I agree with these terms"
-        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
         expect(user.reload.accepted_tos_version).not_to be_nil
         expect(page).to have_content("you need to authorize your account with a valid authorization")
       end
@@ -105,14 +107,14 @@ describe "Forced verifications" do
       let(:user) { create(:user, :confirmed, :admin, organization:) }
 
       it "requires verification" do
-        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
       end
 
       context "and visits the admin" do
         let(:restricted_path) { "/admin" }
 
         it "can visit an admin path" do
-          expect(page).to have_current_path(restricted_path, ignore_query: true)
+          expect(page).to have_current_path(localized_restricted_path, ignore_query: true)
         end
       end
     end
@@ -138,7 +140,7 @@ describe "Forced verifications" do
       end
 
       it "user is redirected and shows the pending" do
-        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
         expect(page).to have_no_content("Verify with Identity documents")
         expect(page).to have_content("Identity documents")
         expect(page).to have_content("Verify with Example authorization")
@@ -155,7 +157,7 @@ describe "Forced verifications" do
       end
 
       it "user is redirected and shows the granted" do
-        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
         expect(page).to have_content("GRANTED VERIFICATIONS")
         expect(page).to have_content("NOT VERIFIED YET")
         expect(page).to have_no_content("PENDING VERIFICATIONS")
@@ -170,7 +172,7 @@ describe "Forced verifications" do
       end
 
       it "acts as normal" do
-        expect(page).to have_current_path(restricted_path, ignore_query: true)
+        expect(page).to have_current_path(localized_restricted_path, ignore_query: true)
       end
     end
 
@@ -179,7 +181,7 @@ describe "Forced verifications" do
 
       it "acts as normal" do
         expect(page).to have_content("Log in")
-        expect(page).to have_current_path("/users/sign_in")
+        expect(page).to have_current_path("/en/users/sign_in")
       end
     end
 
@@ -189,7 +191,7 @@ describe "Forced verifications" do
       it "blocks access" do
         expect(page).to have_content("This account has been blocked")
         # Log out the user
-        expect(page).to have_current_path(decidim.user_session_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim.user_session_path(redirect_url: localized_redirect))
       end
     end
 
@@ -206,7 +208,7 @@ describe "Forced verifications" do
       end
 
       it "acts as normal" do
-        expect(page).to have_current_path(restricted_path, ignore_query: true)
+        expect(page).to have_current_path(localized_restricted_path, ignore_query: true)
       end
     end
 
@@ -228,14 +230,14 @@ describe "Forced verifications" do
 
       it "applies everywhere when there are no constraints (always)" do
         visit restricted_path
-        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(redirect_url: restricted_path))
+        expect(page).to have_current_path(decidim_decidim_awesome.required_authorizations_path(locale: :en, redirect_url: localized_redirect))
       end
 
       it "never applies when a 'none' constraint is present" do
         create(:config_constraint, awesome_config: group_subconfig, settings: { "participatory_space_manifest" => "none" })
 
         visit restricted_path
-        expect(page).to have_current_path(restricted_path, ignore_query: true)
+        expect(page).to have_current_path(localized_restricted_path, ignore_query: true)
       end
 
       it "assemblies manifest requires auth on assembly, not on processes" do


### PR DESCRIPTION
Adapts the forced verifications feature to Decidim 0.32.

- [x] Fix the authorization groups form field names: Rack 3 (Rails 8.1) parses the previous double-bracket names differently than Rack 2, breaking the params structure and failing the permission check on save
- [x] Fix the inline label editor (shared by styles, custom fields, admins and verifications): listen on `keydown` instead of the deprecated `keypress`, recent Chrome no longer cancels the implicit form submission on `keypress` preventDefault, so pressing Enter submitted the whole config form and overwrote the rename
- [x] Guard the label editor against the blur fired by recent Chrome when the focused input is removed, which reverted the freshly saved key
- [x] Update specs