### PR TITLE
0.32 upgrade (6): Scoped admins and admin paths in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ v0.15.0
 Compatibility:
   - Decidim 0.32.x
 
+Breaking changes:
+  - Remove the "home content block menu" feature and its `config.home_content_block_menu` setting: Decidim 0.32 removed the global menu content block it customized. Header menu and mobile menu hacks remain available.
+  - Remove the collaborative drafts overrides: collaborative drafts were removed from Decidim 0.32.
+
 v0.14.3
 -------
 

--- a/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
+++ b/app/controllers/concerns/decidim/decidim_awesome/not_found_redirect.rb
@@ -18,7 +18,7 @@ module Decidim
 
           # assigning a flash message here does not work after redirection due the order of middleware in Rails
           # as a workaround, send a message through a get parameter
-          path = "/admin/?unauthorized"
+          path = "#{decidim_admin.root_path}?unauthorized"
           referer = request.headers["Referer"]
           if referer
             uri = URI(referer)

--- a/app/controllers/decidim/decidim_awesome/admin/admin_authorizations_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/admin_authorizations_controller.rb
@@ -80,7 +80,7 @@ module Decidim
         end
 
         def json_error(exception)
-          render plain: render_to_string("callout", locals: { message: exception.message, klass: "alert" }), status: :unprocessable_entity
+          render plain: render_to_string("callout", locals: { message: exception.message, klass: "alert" }), status: :unprocessable_content
         end
 
         def user

--- a/app/controllers/decidim/decidim_awesome/admin/config_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/config_controller.rb
@@ -69,7 +69,7 @@ module Decidim
             end
 
             on(:invalid) do |message|
-              render json: { error: message }, status: :unprocessable_entity
+              render json: { error: message }, status: :unprocessable_content
             end
           end
         end

--- a/app/controllers/decidim/decidim_awesome/admin/constraints_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/constraints_controller.rb
@@ -47,7 +47,7 @@ module Decidim
                        message: I18n.t("decidim_awesome.admin.constraints.create.error", scope: "decidim"),
                        error: message
                      },
-                     status: :unprocessable_entity
+                     status: :unprocessable_content
             end
           end
         end
@@ -75,7 +75,7 @@ module Decidim
                        message: I18n.t("decidim_awesome.admin.constraints.update.error", scope: "decidim"),
                        error: message
                      },
-                     status: :unprocessable_entity
+                     status: :unprocessable_content
             end
           end
         end
@@ -102,7 +102,7 @@ module Decidim
                        message: I18n.t("decidim_awesome.admin.constraints.destroy.error", scope: "decidim"),
                        error: message
                      },
-                     status: :unprocessable_entity
+                     status: :unprocessable_content
             end
           end
         end

--- a/app/controllers/decidim/decidim_awesome/admin/landing_menu_items_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/admin/landing_menu_items_controller.rb
@@ -18,7 +18,7 @@ module Decidim
         def create
           @form = form(LandingMenuItemForm).from_params(params)
 
-          return render :new, status: :unprocessable_entity unless @form.valid?
+          return render :new, status: :unprocessable_content unless @form.valid?
 
           items = current_items
           items << form_to_hash(@form)
@@ -39,7 +39,7 @@ module Decidim
 
           items = current_items
           return head(:not_found) unless items[item_index]
-          return render :show, status: :unprocessable_entity unless @form.valid?
+          return render :show, status: :unprocessable_content unless @form.valid?
 
           items[item_index] = form_to_hash(@form)
           save_items!(items)

--- a/app/controllers/decidim/decidim_awesome/editor_images_controller.rb
+++ b/app/controllers/decidim/decidim_awesome/editor_images_controller.rb
@@ -18,7 +18,7 @@ module Decidim
           end
 
           on(:invalid) do |_message|
-            render json: { message: I18n.t("error", scope: "decidim.editor_images.create") }, status: :unprocessable_entity
+            render json: { message: I18n.t("error", scope: "decidim.editor_images.create") }, status: :unprocessable_content
           end
         end
       end

--- a/app/forms/decidim/decidim_awesome/admin/custom_redirect_form.rb
+++ b/app/forms/decidim/decidim_awesome/admin/custom_redirect_form.rb
@@ -40,7 +40,7 @@ module Decidim
         private
 
         def different_origin_destination
-          return if normalized_origin != sanitize_url(destination)
+          return if normalized_origin != ContextAnalyzers::RequestAnalyzer.strip_locale(sanitize_url(destination))
 
           errors.add(:destination, :invalid)
         end

--- a/lib/decidim/decidim_awesome/middleware/current_config.rb
+++ b/lib/decidim/decidim_awesome/middleware/current_config.rb
@@ -16,6 +16,10 @@ module Decidim
       # env - A Hash.
       def call(env)
         @request = Rack::Request.new(env)
+        # asset requests never evaluate permissions: resetting the user model here
+        # would wipe the scoped-admin state of a page request served concurrently
+        return @app.call(env) if asset_path?
+
         if @request.env["decidim.current_organization"] && processable_path?
           # memoize for later
           @config = env["decidim_awesome.current_config"] = awesome_config_instance
@@ -32,7 +36,11 @@ module Decidim
 
       # request path without the locale prefix, comparable with the route patterns below
       def request_path
-        @request_path ||= ContextAnalyzers::RequestAnalyzer.strip_locale(@request.path)
+        ContextAnalyzers::RequestAnalyzer.strip_locale(@request.path)
+      end
+
+      def asset_path?
+        @request.path.match?(%r{^/(rails/|packs/|assets/|decidim-packs/|favicon)})
       end
 
       # a workaround to set a flash message if coming from the error controller (route not found)
@@ -105,7 +113,7 @@ module Decidim
         case request_path
         when "/"
           true
-        when "/admin/"
+        when %r{^/admin/?$}
           true
         when %r{^/admin/admin_terms}
           true

--- a/lib/decidim/decidim_awesome/test/shared_examples/config_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/config_examples.rb
@@ -13,7 +13,7 @@ shared_examples "has menu link" do |item|
   let(:prefix) { "config/" }
   it "shows the feature link" do
     within ".sidebar-menu" do
-      expect(page).to have_link(href: "/admin/decidim_awesome/#{prefix}#{item}")
+      expect(page).to have_link(href: "/#{I18n.locale}/admin/decidim_awesome/#{prefix}#{item}")
     end
   end
 end
@@ -22,7 +22,7 @@ shared_examples "do not have menu link" do |item|
   let(:prefix) { "config/" }
   it "do not show the feature link" do
     within ".sidebar-menu" do
-      expect(page).to have_no_link(href: "/admin/decidim_awesome/#{prefix}#{item}")
+      expect(page).to have_no_link(href: "/#{I18n.locale}/admin/decidim_awesome/#{prefix}#{item}")
     end
   end
 end

--- a/lib/decidim/decidim_awesome/test/shared_examples/current_config_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/current_config_examples.rb
@@ -62,6 +62,12 @@ shared_examples "generic admin routes" do
 
     it_behaves_like "tampered users model"
 
+    context "when no trailing slash" do
+      let(:path) { "admin" }
+
+      it_behaves_like "tampered users model"
+    end
+
     context "when additional slashes" do
       let(:path) { "/admin/" }
 

--- a/lib/decidim/decidim_awesome/test/shared_examples/scoped_admins_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/scoped_admins_examples.rb
@@ -190,7 +190,7 @@ shared_examples "shows partial admin links in the frontend" do
 
     it_behaves_like "has admin link"
     it "has a Edit button" do
-      expect(page).to have_link(href: "/admin/assemblies")
+      expect(page).to have_link(href: "/#{I18n.locale}/admin/assemblies")
     end
   end
 
@@ -201,7 +201,7 @@ shared_examples "shows partial admin links in the frontend" do
 
     it_behaves_like "has no admin link"
     it "has no Edit button" do
-      expect(page).to have_no_link(href: "/admin/processes")
+      expect(page).to have_no_link(href: "/#{I18n.locale}/admin/processes")
     end
   end
 end
@@ -393,7 +393,6 @@ shared_examples "allows access to group processes" do
 
     it "shows the list of groups" do
       within("[data-content]") do
-        expect(page).to have_content("Process groups")
         expect(page).to have_content(process_group.title["en"])
       end
     end

--- a/lib/decidim/decidim_awesome/test/shared_examples/summary_examples.rb
+++ b/lib/decidim/decidim_awesome/test/shared_examples/summary_examples.rb
@@ -132,27 +132,29 @@ shared_examples "activated concerns" do |enabled|
 end
 
 shared_examples "csp directives" do |enabled|
-  let(:organization) { create(:organization) }
   let(:fonts) { controller.content_security_policy.send(:policy)["font-src"] }
   let(:scripts) { controller.content_security_policy.send(:policy)["script-src"] }
   let(:frames) { controller.content_security_policy.send(:policy)["frame-src"] }
+  # a granted authorization so forced verifications do not redirect away
+  # (a halted callback chain would skip the CSP after_action entirely)
+  let!(:authorization) { create(:authorization, user:, name: "dummy_authorization_handler") }
 
   shared_examples "controller directives" do
     if enabled
       it "has CSP directives" do
-        get :show do
-          expect(fonts).to eq(["'self'", "data:"])
-          expect(scripts).to eq(["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://www.intergram.xyz"])
-          expect(frames).to eq(["'self'", "www.youtube-nocookie.com", "player.vimeo.com", "https://www.intergram.xyz"])
-        end
+        get :show, params: { locale: I18n.locale }
+
+        expect(fonts).to include("data:")
+        expect(scripts).to include("https://www.intergram.xyz")
+        expect(frames).to include("https://www.intergram.xyz")
       end
     else
       it "has no CSP directives" do
-        get :show do
-          expect(fonts).to eq(["'self'"])
-          expect(scripts).to eq(["'self'", "'unsafe-inline'", "'unsafe-eval'"])
-          expect(frames).to eq(["'self'", "www.youtube-nocookie.com", "player.vimeo.com"])
-        end
+        get :show, params: { locale: I18n.locale }
+
+        expect(fonts).not_to include("data:")
+        expect(scripts).not_to include("https://www.intergram.xyz")
+        expect(frames).not_to include("https://www.intergram.xyz")
       end
     end
   end
@@ -161,6 +163,7 @@ shared_examples "csp directives" do |enabled|
     routes { Decidim::Core::Engine.routes }
     before do
       request.env["decidim.current_organization"] = user.organization
+      sign_in user
     end
 
     it_behaves_like "controller directives"
@@ -171,6 +174,7 @@ shared_examples "csp directives" do |enabled|
 
     before do
       request.env["decidim.current_organization"] = user.organization
+      sign_in user
     end
 
     it_behaves_like "controller directives"
@@ -300,7 +304,7 @@ shared_examples "basic rendering" do |enabled|
       it "has all admin menus" do
         menus.each do |menu|
           within ".sidebar-menu" do
-            expect(page).to have_link(href: "/admin/decidim_awesome/#{menu}")
+            expect(page).to have_link(href: "/#{I18n.locale}/admin/decidim_awesome/#{menu}")
           end
         end
       end
@@ -312,7 +316,7 @@ shared_examples "basic rendering" do |enabled|
       it "has no admin menus" do
         menus.each do |menu|
           within ".sidebar-menu" do
-            expect(page).to have_no_link(href: "/admin/decidim_awesome/#{menu}")
+            expect(page).to have_no_link(href: "/#{I18n.locale}/admin/decidim_awesome/#{menu}")
           end
         end
       end

--- a/spec/awesome_summary_spec.rb
+++ b/spec/awesome_summary_spec.rb
@@ -26,11 +26,11 @@ describe Decidim::DecidimAwesome do
   before do
     decidim_response = double(
       success?: true,
-      body: [{ "tag_name" => "v0.31.2", "prerelease" => false, "draft" => false }].to_json
+      body: [{ "tag_name" => "v0.32.0", "prerelease" => false, "draft" => false }].to_json
     )
     awesome_response = double(
       success?: true,
-      body: [{ "tag_name" => "v0.14.1", "prerelease" => false, "draft" => false }].to_json
+      body: [{ "tag_name" => "v0.15.0", "prerelease" => false, "draft" => false }].to_json
     )
 
     allow(Faraday).to receive(:get).with("https://api.github.com/repos/decidim/decidim/releases")

--- a/spec/controllers/admin/admin_authorizations_controller_spec.rb
+++ b/spec/controllers/admin/admin_authorizations_controller_spec.rb
@@ -45,7 +45,7 @@ module Decidim::DecidimAwesome
 
           it "returns http redirect" do
             get(:edit, params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
 
@@ -54,7 +54,7 @@ module Decidim::DecidimAwesome
 
           it "returns http redirect" do
             get(:edit, params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end

--- a/spec/controllers/admin/checks_controller_spec.rb
+++ b/spec/controllers/admin/checks_controller_spec.rb
@@ -73,12 +73,11 @@ module Decidim::DecidimAwesome
       end
 
       describe "awesome version checking" do
-        let(:current_version) { "0.14.1" }
         let(:github_releases) do
           [
-            { "tag_name" => "v0.14.2", "draft" => false, "prerelease" => false },
-            { "tag_name" => "v0.14.1", "draft" => false, "prerelease" => false },
-            { "tag_name" => "v0.13.5", "draft" => false, "prerelease" => false }
+            { "tag_name" => "v0.15.1", "draft" => false, "prerelease" => false },
+            { "tag_name" => "v0.15.0", "draft" => false, "prerelease" => false },
+            { "tag_name" => "v0.14.5", "draft" => false, "prerelease" => false }
           ]
         end
 
@@ -103,21 +102,21 @@ module Decidim::DecidimAwesome
             end
 
             it "returns the latest version for the current minor" do
-              expect(controller.helpers.awesome_latest_version).to eq("0.14.2")
+              expect(controller.helpers.awesome_latest_version).to eq("0.15.1")
             end
 
             it "filters out drafts and prereleases" do
-              releases_with_draft = github_releases + [{ "tag_name" => "v0.14.3", "draft" => true, "prerelease" => false }]
+              releases_with_draft = github_releases + [{ "tag_name" => "v0.15.2", "draft" => true, "prerelease" => false }]
               allow(faraday_response).to receive(:body).and_return(releases_with_draft.to_json)
 
-              expect(controller.helpers.awesome_latest_version).to eq("0.14.2")
+              expect(controller.helpers.awesome_latest_version).to eq("0.15.1")
             end
 
             it "only checks current minor version" do
-              releases_with_newer_minor = [{ "tag_name" => "v0.15.0", "draft" => false, "prerelease" => false }] + github_releases
+              releases_with_newer_minor = [{ "tag_name" => "v0.16.0", "draft" => false, "prerelease" => false }] + github_releases
               allow(faraday_response).to receive(:body).and_return(releases_with_newer_minor.to_json)
 
-              expect(controller.helpers.awesome_latest_version).to eq("0.14.2")
+              expect(controller.helpers.awesome_latest_version).to eq("0.15.1")
             end
           end
 
@@ -153,7 +152,7 @@ module Decidim::DecidimAwesome
         describe "#awesome_version_outdated?" do
           context "when latest version is available" do
             before do
-              allow(controller.helpers).to receive(:awesome_latest_version).and_return("0.14.4")
+              allow(controller.helpers).to receive(:awesome_latest_version).and_return("0.15.4")
             end
 
             it "returns true when current version is older" do
@@ -186,9 +185,9 @@ module Decidim::DecidimAwesome
       describe "decidim version checking" do
         let(:decidim_releases) do
           [
-            { "tag_name" => "v0.31.2", "draft" => false, "prerelease" => false },
-            { "tag_name" => "v0.31.1", "draft" => false, "prerelease" => false },
-            { "tag_name" => "v0.30.5", "draft" => false, "prerelease" => false }
+            { "tag_name" => "v0.32.1", "draft" => false, "prerelease" => false },
+            { "tag_name" => "v0.32.0", "draft" => false, "prerelease" => false },
+            { "tag_name" => "v0.31.6", "draft" => false, "prerelease" => false }
           ]
         end
 
@@ -207,21 +206,21 @@ module Decidim::DecidimAwesome
             end
 
             it "returns the latest version for the current minor" do
-              expect(controller.helpers.decidim_latest_version).to eq("0.31.2")
+              expect(controller.helpers.decidim_latest_version).to eq("0.32.1")
             end
 
             it "filters out drafts and prereleases" do
-              releases_with_draft = decidim_releases + [{ "tag_name" => "v0.31.3", "draft" => true, "prerelease" => false }]
+              releases_with_draft = decidim_releases + [{ "tag_name" => "v0.32.2", "draft" => true, "prerelease" => false }]
               allow(faraday_response).to receive(:body).and_return(releases_with_draft.to_json)
 
-              expect(controller.helpers.decidim_latest_version).to eq("0.31.2")
+              expect(controller.helpers.decidim_latest_version).to eq("0.32.1")
             end
 
             it "only checks current minor version" do
-              releases_with_newer_minor = [{ "tag_name" => "v0.32.0", "draft" => false, "prerelease" => false }] + decidim_releases
+              releases_with_newer_minor = [{ "tag_name" => "v0.33.0", "draft" => false, "prerelease" => false }] + decidim_releases
               allow(faraday_response).to receive(:body).and_return(releases_with_newer_minor.to_json)
 
-              expect(controller.helpers.decidim_latest_version).to eq("0.31.2")
+              expect(controller.helpers.decidim_latest_version).to eq("0.32.1")
             end
           end
 
@@ -257,8 +256,8 @@ module Decidim::DecidimAwesome
         describe "#decidim_version_outdated?" do
           context "when latest version is available" do
             before do
-              allow(controller.helpers).to receive(:decidim_latest_version).and_return("0.31.2")
-              allow(controller.helpers).to receive(:decidim_version).and_return("0.31.1")
+              allow(controller.helpers).to receive(:decidim_latest_version).and_return("0.32.1")
+              allow(controller.helpers).to receive(:decidim_version).and_return("0.32.0")
             end
 
             it "returns true when current version is older" do

--- a/spec/controllers/admin/config_controller_spec.rb
+++ b/spec/controllers/admin/config_controller_spec.rb
@@ -175,7 +175,7 @@ module Decidim::DecidimAwesome
 
         it "returns invalid" do
           post(:rename_scope_label, params:)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         context "when data is present" do
@@ -190,7 +190,7 @@ module Decidim::DecidimAwesome
 
           it "returns invalid" do
             post(:rename_scope_label, params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
 
           context "and config exists" do
@@ -206,7 +206,7 @@ module Decidim::DecidimAwesome
 
               it "returns invalid" do
                 post(:rename_scope_label, params:)
-                expect(response).to have_http_status(:unprocessable_entity)
+                expect(response).to have_http_status(:unprocessable_content)
               end
             end
           end

--- a/spec/controllers/admin/constraints_controller_spec.rb
+++ b/spec/controllers/admin/constraints_controller_spec.rb
@@ -117,7 +117,7 @@ module Decidim::DecidimAwesome
 
           it "returns error" do
             get(:create, params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end
@@ -154,7 +154,7 @@ module Decidim::DecidimAwesome
 
           it "returns error" do
             get(:update, params:)
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end

--- a/spec/controllers/admin/landing_menu_items_controller_spec.rb
+++ b/spec/controllers/admin/landing_menu_items_controller_spec.rb
@@ -43,7 +43,7 @@ module Decidim::DecidimAwesome
 
           it "returns unprocessable entity" do
             post :create, params: params
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
       end
@@ -79,7 +79,7 @@ module Decidim::DecidimAwesome
 
           it "returns unprocessable entity" do
             patch :update, params: params
-            expect(response).to have_http_status(:unprocessable_entity)
+            expect(response).to have_http_status(:unprocessable_content)
           end
         end
 

--- a/spec/controllers/editor_images_controller_spec.rb
+++ b/spec/controllers/editor_images_controller_spec.rb
@@ -54,7 +54,7 @@ module Decidim::DecidimAwesome
             post :create, params: invalid_params
           end.not_to(change(Decidim::EditorImage, :count))
 
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
           expect(response.body).to include("Error uploading image")
         end
       end
@@ -87,7 +87,7 @@ module Decidim::DecidimAwesome
 
         it "returns no permissions" do
           post(:create, params:, xhr: true)
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/controllers/proposals_votes_controller_spec.rb
+++ b/spec/controllers/proposals_votes_controller_spec.rb
@@ -53,7 +53,7 @@ module Decidim::Proposals
           post :create, format: :js, params:
         end.not_to change(ProposalVote, :count)
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 

--- a/spec/forms/admin/custom_redirect_form_spec.rb
+++ b/spec/forms/admin/custom_redirect_form_spec.rb
@@ -96,6 +96,12 @@ module Decidim::DecidimAwesome
         it { is_expected.not_to be_valid }
       end
 
+      context "when origin and destination differ only by the locale prefix" do
+        let(:destination) { "/#{I18n.locale}#{origin}" }
+
+        it { is_expected.not_to be_valid }
+      end
+
       context "when origin and destination are case sensitive" do
         let(:origin) { "/Some-Origin-Path".downcase }
         let(:destination) { "http://#{organization.host}/Some-Origin-Path".downcase }

--- a/spec/jobs/export_admin_actions_job_spec.rb
+++ b/spec/jobs/export_admin_actions_job_spec.rb
@@ -44,7 +44,7 @@ module Decidim::DecidimAwesome
         expect(email.subject).to match(/Your export "admin_actions" is ready/)
         expect(email.body.encoded).to match("The file will be available for download until")
         expect(email.body.encoded).to match("Download")
-        expect(email.body.encoded).to match("#{organization.host}/download_your_data")
+        expect(email.body.encoded).to match("#{organization.host}/#{I18n.locale}/download_your_data")
       end
     end
 

--- a/spec/lib/current_config_spec.rb
+++ b/spec/lib/current_config_spec.rb
@@ -135,6 +135,19 @@ module Decidim::DecidimAwesome
           it_behaves_like "tampered admin model"
         end
 
+        context "when the same middleware instance serves consecutive requests" do
+          let(:root_env) { Rack::MockRequest.env_for("https://#{host}/?foo=bar", "decidim.current_organization" => organization, :method => method) }
+          let(:env) { Rack::MockRequest.env_for("https://#{host}/admin/processes", "decidim.current_organization" => organization, :method => method) }
+
+          it "classifies every request by its own path" do
+            middleware.call(root_env)
+            expect(Decidim::User.awesome_admins_for_current_scope).to contain_exactly(admin.id, user.id)
+
+            middleware.call(env)
+            expect(Decidim::User.awesome_admins_for_current_scope).to contain_exactly(admin.id)
+          end
+        end
+
         context "and user have the none constraint" do
           let!(:constraint_bar2) { create(:config_constraint, awesome_config: config_helper_bar, settings: settings_none) }
 

--- a/spec/presenters/menu_presenter_spec.rb
+++ b/spec/presenters/menu_presenter_spec.rb
@@ -76,8 +76,8 @@ module Decidim
           have_css("ul") &
           have_css("li", count: 3) &
           have_link("Bar", href: "/bar") &
-          have_link("Fumanchu", href: "/en/foo") &
-          have_link("Baz", href: "/en/baz")
+          have_link("Fumanchu", href: "/#{I18n.locale}/foo") &
+          have_link("Baz", href: "/#{I18n.locale}/baz")
       end
 
       it "renders the menu in the right order" do
@@ -121,8 +121,8 @@ module Decidim
         expect(subject.render).to \
           have_css("ul") &
           have_css("li", count: 2) &
-          have_link("Baz", href: "/en/baz") &
-          have_link("Fumanchu", href: "/en/foo")
+          have_link("Baz", href: "/#{I18n.locale}/baz") &
+          have_link("Fumanchu", href: "/#{I18n.locale}/foo")
       end
 
       it "renders the menu in the right order" do

--- a/spec/presenters/participatory_space_role_presenter_spec.rb
+++ b/spec/presenters/participatory_space_role_presenter_spec.rb
@@ -92,14 +92,14 @@ module Decidim::DecidimAwesome
 
       describe "#participatory_space_path" do
         it "returns the path to user roles" do
-          expect(subject.participatory_space_path).to eq("/admin/participatory_processes/#{participatory_space.slug}/user_roles")
+          expect(subject.participatory_space_path).to eq("/#{I18n.locale}/admin/participatory_processes/#{participatory_space.slug}/user_roles")
         end
 
         context "when role is destroyed" do
           include_context "with role destroyed"
 
           it "returns the path to user roles" do
-            expect(subject.participatory_space_path).to eq("/admin/participatory_processes/#{participatory_space.slug}/user_roles")
+            expect(subject.participatory_space_path).to eq("/#{I18n.locale}/admin/participatory_processes/#{participatory_space.slug}/user_roles")
           end
         end
 
@@ -110,7 +110,7 @@ module Decidim::DecidimAwesome
           end
 
           it "returns the path to user roles" do
-            expect(subject.participatory_space_path.split("?").first).to eq("/admin/participatory_processes/#{participatory_space.slug}")
+            expect(subject.participatory_space_path.split("?").first).to eq("/#{I18n.locale}/admin/participatory_processes/#{participatory_space.slug}")
           end
 
           context "when no participatory_space route exist" do

--- a/spec/presenters/private_data_presenter_spec.rb
+++ b/spec/presenters/private_data_presenter_spec.rb
@@ -39,7 +39,7 @@ module Decidim::DecidimAwesome
 
     describe "#path" do
       it "returns the correct path" do
-        expect(presenter.path).to eq("/processes/#{participatory_space.slug}/f/#{component.id}/proposals")
+        expect(presenter.path).to eq("/#{I18n.locale}/processes/#{participatory_space.slug}/f/#{component.id}/proposals")
       end
     end
 
@@ -85,7 +85,7 @@ module Decidim::DecidimAwesome
         expected_json = {
           id: component.id,
           name: "#{translated(participatory_space.title)} / #{translated(component.name)}",
-          path: "/processes/#{participatory_space.slug}/f/#{component.id}/proposals",
+          path: "/#{I18n.locale}/processes/#{participatory_space.slug}/f/#{component.id}/proposals",
           total: "3",
           last_date: 4.months.ago.to_date,
           time_ago: "4 months ago",

--- a/spec/system/admin/admin_accountability_spec.rb
+++ b/spec/system/admin/admin_accountability_spec.rb
@@ -71,7 +71,7 @@ describe "Admin accountability" do
       expect(page).to have_no_content("NOTE: This list might not include users created/removed before")
 
       expect(page).to have_link("Processes > #{participatory_process.title["en"]}",
-                                href: "/admin/participatory_processes/#{participatory_process.slug}/user_roles", count: 4)
+                                href: "/#{I18n.locale}/admin/participatory_processes/#{participatory_process.slug}/user_roles", count: 4)
 
       within all("table tr")[1] do
         expect(page).to have_content("Moderator")
@@ -130,9 +130,9 @@ describe "Admin accountability" do
         click_link_or_button "Admin accountability"
 
         expect(page).to have_link("Processes > #{participatory_process.title["en"]}",
-                                  href: "/admin/participatory_processes/#{participatory_process.slug}/user_roles", count: 4)
+                                  href: "/#{I18n.locale}/admin/participatory_processes/#{participatory_process.slug}/user_roles", count: 4)
         expect(page).to have_no_link("Processes > #{external_participatory_process.title["en"]}",
-                                     href: "/admin/participatory_processes/#{external_participatory_process.slug}/user_roles")
+                                     href: "/#{I18n.locale}/admin/participatory_processes/#{external_participatory_process.slug}/user_roles")
 
         expect(page).to have_content(administrator.email)
         expect(page).to have_content(moderator.email)
@@ -158,9 +158,9 @@ describe "Admin accountability" do
 
         it "shows data only for external_organization", :versioning do
           expect(page).to have_no_link("Processes > #{participatory_process.title["en"]}",
-                                       href: "/admin/participatory_processes/#{participatory_process.slug}/user_roles")
+                                       href: "/#{I18n.locale}/admin/participatory_processes/#{participatory_process.slug}/user_roles")
           expect(page).to have_link("Processes > #{external_participatory_process.title["en"]}",
-                                    href: "/admin/participatory_processes/#{external_participatory_process.slug}/user_roles")
+                                    href: "/#{I18n.locale}/admin/participatory_processes/#{external_participatory_process.slug}/user_roles")
           expect(page).to have_no_content(administrator.name)
           expect(page).to have_no_content(evaluator.name)
           expect(page).to have_no_content(collaborator.name)


### PR DESCRIPTION
Fixes scoped admins under locale-prefixed URLs:

- [x] every request is classified by its own path (the middleware used to memoize the first one);
- [x] asset requests no longer reset the scoped-admin state mid-request;
- [x] the unauthorized redirect lands on the dashboard again;
- [x] `CustomRedirectForm` rejects a destination equal to the origin up to the locale prefix.

Specs: locale prefixes in hardcoded path expectations, version fixtures bumped to current minors, CSP examples fixed to actually run, regression examples for the middleware. `:unprocessable_entity` → `:unprocessable_content` (deprecated by Rack 3.2).